### PR TITLE
Use a less obsolete java version

### DIFF
--- a/jung/pom.xml
+++ b/jung/pom.xml
@@ -99,8 +99,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.0</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Use a less obsolete java version, but keep it old because: android. We may choose to move past this, but we'll do at least one release at 1.6.