### PR TITLE
Add a release profile and fix up the plugin management section, configuring for release, etc.

### DIFF
--- a/jung/pom.xml
+++ b/jung/pom.xml
@@ -96,34 +96,29 @@
     </developer>
   </developers>
   <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-source-plugin</artifactId>
-        <configuration>
-          <includePom>true</includePom>
-        </configuration>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <source>1.6</source>
+            <target>1.6</target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.5</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <configuration>
+            <mavenExecutorId>forked-path</mavenExecutorId>
+            <useReleaseProfile>false</useReleaseProfile>
+            <arguments>${arguments} -Psonatype-oss-release</arguments>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
   <reporting>
     <plugins>
@@ -195,6 +190,55 @@
         <module>jung-io</module>
         <module>jung-visualization</module>
         <module>jung-samples</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>sonatype-oss-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.1</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <modules>
+        <module>jung-api</module>
+        <module>jung-graph-impl</module>
+        <module>jung-algorithms</module>
+        <module>jung-io</module>
+        <module>jung-visualization</module>
       </modules>
     </profile>
   </profiles>

--- a/jung/pom.xml
+++ b/jung/pom.xml
@@ -51,6 +51,14 @@
   <prerequisites>
     <maven>3.1.1</maven>
   </prerequisites>
+  <modules>
+    <module>jung-api</module>
+    <module>jung-graph-impl</module>
+    <module>jung-algorithms</module>
+    <module>jung-io</module>
+    <module>jung-visualization</module>
+    <module>jung-samples</module>
+  </modules>  
   <developers>
     <developer>
       <id>eflat</id>
@@ -183,14 +191,6 @@
           <name>all</name>
         </property>
       </activation>
-      <modules>
-        <module>jung-api</module>
-        <module>jung-graph-impl</module>
-        <module>jung-algorithms</module>
-        <module>jung-io</module>
-        <module>jung-visualization</module>
-        <module>jung-samples</module>
-      </modules>
     </profile>
     <profile>
       <id>sonatype-oss-release</id>
@@ -233,13 +233,6 @@
           </plugin>
         </plugins>
       </build>
-      <modules>
-        <module>jung-api</module>
-        <module>jung-graph-impl</module>
-        <module>jung-algorithms</module>
-        <module>jung-io</module>
-        <module>jung-visualization</module>
-      </modules>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This sets up a profile that generates -sources and -javadoc jars, does gpg signing, all in service of Sonatype policies, and fixes some smaller things (moving inherited plugin configuration into the management section, so it doesn't invoke the plugins on every child build, but merely configures it if plugins are invoked. 