### PR TITLE
Use the after_success phase rather than the deploy phase.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 script:
   - mvn -B verify -U -Dmaven.javadoc.skip=true
 
-deploy:
+after_success:
   - tools/deploy_snapshot.sh
 
 cache:


### PR DESCRIPTION
Fix travis deploy script, which was failing at parse, because 'deploy' isn't a phase that can be overridden, only to configure a stock deployment.  Use after_success instead.  Note, this was undetected because of https://github.com/travis-ci/travis-ci/issues/2991 (the linter is broken and didn't recognize the bad deploy segment).