### PR TITLE
Remove woodstox dependency

### DIFF
--- a/jung-io/pom.xml
+++ b/jung-io/pom.xml
@@ -27,11 +27,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.woodstox</groupId>
-      <artifactId>wstx-asl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>net.sf.jung</groupId>
       <artifactId>jung-graph-impl</artifactId>
       <version>${project.version}</version>

--- a/jung-io/src/test/java/edu/uci/ics/jung/io/graphml/TestGraphMLReader2.java
+++ b/jung-io/src/test/java/edu/uci/ics/jung/io/graphml/TestGraphMLReader2.java
@@ -191,7 +191,7 @@ public class TestGraphMLReader2 {
         Assert.assertEquals("n2", edges.get(0).getEndpoints().get(2).getNode());
     }
 
-    @Test(expected = GraphIOException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testInvalidGraphFactory() throws Exception {
 
         // Need a hypergraph
@@ -208,6 +208,8 @@ public class TestGraphMLReader2 {
                 + "<endpoint node=\"n0\"/>" + "<endpoint node=\"n1\"/>"
                 + "<endpoint node=\"n2\"/>" + "</hyperedge>" + "</graphml>";
 
+	// This will attempt to add an edge with an invalid number of incident vertices (3)
+	// for an UndirectedGraph, which should trigger an IllegalArgumentException.
         readGraph(xml, new DummyGraphObjectBase.UndirectedSparseGraphFactory(),
                 new DummyVertex.Factory(), new DummyEdge.EdgeFactory(), new DummyEdge.HyperEdgeFactory());
     }


### PR DESCRIPTION
And fix TestGraphMLReader2.testInvalidGraphFactory(), which was
declaring an exception that it wasn’t actually throwing.  (IDEK why the
woodstox dependency would have been masking that.  :P )