### PR TITLE
Change Guava dependency to v19.0

### DIFF
--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/PersistentLayoutImpl.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/PersistentLayoutImpl.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 
 import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.visualization.util.Caching;
@@ -64,14 +66,9 @@ public class PersistentLayoutImpl<V, E> extends ObservableCachingLayout<V,E>
      */
     public PersistentLayoutImpl(Layout<V,E> layout) {
         super(layout);
-        this.locations = new HashMap<V, Point>();
-        // TODO(jrtom): replace this with Maps.asMap(vertices, factory)
-        // once we depend on Guava 14.0.1 or later; right now we have Guava v11
-        Function<V, Point> factory = new RandomPointFactory<V>(getSize());
-        for (V v : layout.getGraph().getVertices()) {
-        	locations.put(v, factory.apply(v));
-        }
-
+	this.locations = Maps.asMap(
+	    ImmutableSet.copyOf(layout.getGraph().getVertices()),
+	    new RandomPointFactory<V>(getSize()));
         this.dontmove = new HashSet<V>();
     }
 

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/EdgeLabelRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/EdgeLabelRenderer.java
@@ -13,7 +13,6 @@ package edu.uci.ics.jung.visualization.renderers;
 import java.awt.Component;
 import java.awt.Font;
 
-import javax.annotation.Nullable;
 import javax.swing.JComponent;
 
 /**
@@ -37,8 +36,8 @@ public interface EdgeLabelRenderer {
 	 * @param <E> the edge type
 	 * @return the component used for drawing the label
 	 */
-    <E> Component getEdgeLabelRendererComponent(@Nullable JComponent component,
-    		@Nullable Object value, Font font, boolean isSelected, E edge);
+    <E> Component getEdgeLabelRendererComponent(JComponent component,
+    		Object value, Font font, boolean isSelected, E edge);
     
     boolean isRotateEdgeLabels();
     

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,7 @@
   <properties>
     <!-- TODO(cgruber): Audit and update dependencies, particularly google deps. -->
     <junit.version>3.8.1</junit.version>
-    <guava.version>11.0.2</guava.version>
-    <woodstox.version>3.2.6</woodstox.version>
+    <guava.version>19.0</guava.version>
   </properties>
   <developers>
     <developer>
@@ -114,11 +113,6 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.woodstox</groupId>
-        <artifactId>wstx-asl</artifactId>
-        <version>${woodstox.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
EdgeLabelRenderer: remove @Nullable references (it’s the only place
that uses them and I don’t want to muck around with adding dependencies
right now)
PersistentLayoutImpl: use Maps.asMap() now that it’s available in Guava

Remove the last vestiges of the woodstox dependency.