### PR TITLE
Update .travis.yml to reduce duplicate travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,9 @@ cache:
   - ${HOME}/.m2
 
 branches:
-  except:
-    - gh-pages
+  only:
+    - master
+    - /^release.*$/
 
 env:
   global:


### PR DESCRIPTION
Travis builds any non-blacklisted branches unless whitelisted, and also builds P/Rs.  That means that a pull request based on a non-blacklisted branch will build twice.  This simplifies things by simply making a whitelist of "master" and branches prefixed by "release", and pull requests will be built as a matter of course. 