### PR TITLE
Git #44 : Correcting an issue raised in 2.1 where PluggableRenderContext…

### DIFF
--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/BasicVisualizationServer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/BasicVisualizationServer.java
@@ -136,7 +136,6 @@ public class BasicVisualizationServer<V, E> extends JPanel
      */
 	public BasicVisualizationServer(Layout<V,E> layout) {
 	    this(new DefaultVisualizationModel<V,E>(layout));
-	    renderContext = new PluggableRenderContext<V,E>(layout.getGraph());
 	}
 	
     /**
@@ -147,7 +146,6 @@ public class BasicVisualizationServer<V, E> extends JPanel
      */
 	public BasicVisualizationServer(Layout<V,E> layout, Dimension preferredSize) {
 	    this(new DefaultVisualizationModel<V,E>(layout, preferredSize), preferredSize);
-	    renderContext = new PluggableRenderContext<V,E>(layout.getGraph());
 	}
 	
 	/**

--- a/jung-visualization/src/test/java/edu/uci/ics/jung/visualization/BasicVisualizationServerTest.java
+++ b/jung-visualization/src/test/java/edu/uci/ics/jung/visualization/BasicVisualizationServerTest.java
@@ -1,0 +1,23 @@
+package edu.uci.ics.jung.visualization;
+
+import edu.uci.ics.jung.algorithms.layout.CircleLayout;
+import edu.uci.ics.jung.graph.SparseGraph;
+import edu.uci.ics.jung.visualization.picking.PickedState;
+import junit.framework.TestCase;
+
+public class BasicVisualizationServerTest extends TestCase {
+
+  /*
+   * Previously, a bug was introduced where the RenderContext in BasicVisualizationServer was reassigned, resulting
+   * in data like pickedVertexState to be lost.
+   */
+  public void testRenderContextNotOverridden() {
+    SparseGraph<Object, Object> graph = new SparseGraph<Object, Object>();
+    CircleLayout<Object, Object> layout = new CircleLayout<Object, Object>(graph);
+
+    BasicVisualizationServer<Object, Object> server = new BasicVisualizationServer<Object, Object>(layout);
+
+    PickedState<Object> pickedVertexState = server.getRenderContext().getPickedVertexState();
+    assertNotNull(pickedVertexState);
+  }
+}


### PR DESCRIPTION
… is created multiple times during the initialisation of BasicVisualizationServer, resulting in renderContext fields to be discarded. Since all constructors defer to a primary constructor, the other two initialisations of renderContext have been removed.