### PR TITLE
Fixed two NullPointerException when Context.hashcode() is called.

### DIFF
--- a/jung-api/src/main/java/edu/uci/ics/jung/graph/util/DefaultParallelEdgeIndexFunction.java
+++ b/jung-api/src/main/java/edu/uci/ics/jung/graph/util/DefaultParallelEdgeIndexFunction.java
@@ -58,7 +58,8 @@ public class DefaultParallelEdgeIndexFunction<V,E> implements EdgeIndexFunction<
      */
     public int getIndex(Graph<V, E> graph, E e)
     {
-    	checkNotNull(graph);
+    	checkNotNull(graph, "graph must not be null");
+    	checkNotNull(e, "'e' must not be null");
         Integer index = edge_index.get(Context.<Graph<V,E>,E>getInstance(graph,e));
         	//edge_index.get(e);
         if(index == null) {

--- a/jung-api/src/main/java/edu/uci/ics/jung/graph/util/DefaultParallelEdgeIndexFunction.java
+++ b/jung-api/src/main/java/edu/uci/ics/jung/graph/util/DefaultParallelEdgeIndexFunction.java
@@ -11,6 +11,8 @@
  */
 package edu.uci.ics.jung.graph.util;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -56,7 +58,7 @@ public class DefaultParallelEdgeIndexFunction<V,E> implements EdgeIndexFunction<
      */
     public int getIndex(Graph<V, E> graph, E e)
     {
-    	
+    	checkNotNull(graph);
         Integer index = edge_index.get(Context.<Graph<V,E>,E>getInstance(graph,e));
         	//edge_index.get(e);
         if(index == null) {

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/EdgeShape.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/EdgeShape.java
@@ -131,7 +131,7 @@ public class EdgeShape<V,E> {
     private int getIndex(E e, EdgeIndexFunction<V, E> edgeIndexFunction) {
     	return edgeIndexFunction == null
     			? 1
-    			: edgeIndexFunction.getIndex(null, e);
+    			: edgeIndexFunction.getIndex(graph, e);
     }
     
     /**

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicEdgeLabelRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicEdgeLabelRenderer.java
@@ -78,7 +78,7 @@ public class BasicEdgeLabelRenderer<V,E> implements Renderer.EdgeLabel<V,E> {
         
         double parallelOffset = 1;
 
-        parallelOffset += rc.getParallelEdgeIndexFunction().getIndex(null, e);
+        parallelOffset += rc.getParallelEdgeIndexFunction().getIndex(graph, e);
 
         parallelOffset *= d.height;
         if(edgeShape instanceof Ellipse2D) {


### PR DESCRIPTION
In both cases Context.getInstance() was called with a null-graph, which causes a NPE a bit further along when context.hashcode() is called.

I was thinking about a UnitTest, but the expection happens during the AWT-Paint phase, so i scrapped that idea for now. 
The Problem is observable in one of the demos: EdgeLabelDemo

