### PR TITLE
Fix incorrect getRow() calculation

### DIFF
--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/generators/Lattice2DGenerator.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/generators/Lattice2DGenerator.java
@@ -182,7 +182,7 @@ public class Lattice2DGenerator<V,E> implements GraphGenerator<V,E>
      */
     protected int getRow(int i)
     {
-        return i / row_count;
+        return i / col_count;
     }
     
     /**


### PR DESCRIPTION
Addresses issue #53.

The calculation for getRow() was incorrect. Consider the following
scenario. The numbers represent vertices and are arranged in a 2-row,
5-col lattice.

    0 1 2 3 4
    5 6 7 8 9

getRow() currently returns `i / row_count` which means that vertices 2-3
are incorrectly said to be in row 1, 4-5 in row 2 (non-existent), 6-7
in row 3 (non-existent), etc.

Changing it to `i / col_count` produces the desired results: 0-4 are row 0,
5-9 are row 1.