### PR TITLE
New Implementation of Barabasi-Albert generator

### DIFF
--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/generators/random/BarabasiAlbertGenerator.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/generators/random/BarabasiAlbertGenerator.java
@@ -22,216 +22,263 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 
 import edu.uci.ics.jung.algorithms.generators.EvolvingGraphGenerator;
+import edu.uci.ics.jung.algorithms.util.WeightedChoice;
 import edu.uci.ics.jung.graph.Graph;
 import edu.uci.ics.jung.graph.MultiGraph;
 import edu.uci.ics.jung.graph.util.EdgeType;
 import edu.uci.ics.jung.graph.util.Pair;
 
-
 /**
- * <p>Simple evolving scale-free random graph generator. At each time
- * step, a new vertex is created and is connected to existing vertices
- * according to the principle of "preferential attachment", whereby 
- * vertices with higher degree have a higher probability of being 
- * selected for attachment.
+ * <p>
+ * Simple evolving scale-free random graph generator. At each time step, a new
+ * vertex is created and is connected to existing vertices according to the
+ * principle of "preferential attachment", whereby vertices with higher degree
+ * have a higher probability of being selected for attachment.
  * 
- * <p>At a given timestep, the probability <code>p</code> of creating an edge
+ * <p>
+ * At a given timestep, the probability <code>p</code> of creating an edge
  * between an existing vertex <code>v</code> and the newly added vertex is
+ * 
  * <pre>
  * p = (degree(v) + 1) / (|E| + |V|);
  * </pre>
  * 
- * <p>where <code>|E|</code> and <code>|V|</code> are, respectively, the number 
- * of edges and vertices currently in the network (counting neither the new
- * vertex nor the other edges that are being attached to it).
+ * <p>
+ * where <code>|E|</code> and <code>|V|</code> are, respectively, the number of
+ * edges and vertices currently in the network (counting neither the new vertex
+ * nor the other edges that are being attached to it).
  * 
- * <p>Note that the formula specified in the original paper
- * (cited below) was
+ * <p>
+ * Note that the formula specified in the original paper (cited below) was
+ * 
  * <pre>
  * p = degree(v) / |E|
  * </pre>
  * 
  * 
- * <p>However, this would have meant that the probability of attachment for any existing
- * isolated vertex would be 0.  This version uses Lagrangian smoothing to give
- * each existing vertex a positive attachment probability.
+ * <p>
+ * However, this would have meant that the probability of attachment for any
+ * existing isolated vertex would be 0. This version uses Lagrangian smoothing
+ * to give each existing vertex a positive attachment probability.
  * 
- * <p>The graph created may be either directed or undirected (controlled by a constructor
- * parameter); the default is undirected.  
- * If the graph is specified to be directed, then the edges added will be directed
- * from the newly added vertex u to the existing vertex v, with probability proportional to the 
- * indegree of v (number of edges directed towards v).  If the graph is specified to be undirected,
- * then the (undirected) edges added will connect u to v, with probability proportional to the 
- * degree of v. 
+ * <p>
+ * The graph created may be either directed or undirected (controlled by a
+ * constructor parameter); the default is undirected. If the graph is specified
+ * to be directed, then the edges added will be directed from the newly added
+ * vertex u to the existing vertex v, with probability proportional to the
+ * indegree of v (number of edges directed towards v). If the graph is specified
+ * to be undirected, then the (undirected) edges added will connect u to v, with
+ * probability proportional to the degree of v.
  * 
- * <p>The <code>parallel</code> constructor parameter specifies whether parallel edges
- * may be created.
+ * <p>
+ * The <code>parallel</code> constructor parameter specifies whether parallel
+ * edges may be created.
  * 
  * @see "A.-L. Barabasi and R. Albert, Emergence of scaling in random networks, Science 286, 1999."
  * @author Scott White
  * @author Joshua O'Madadhain
  * @author Tom Nelson - adapted to jung2
  */
-public class BarabasiAlbertGenerator<V,E> implements EvolvingGraphGenerator<V,E> {
-    private Graph<V, E> mGraph = null;
-    private int mNumEdgesToAttachPerStep;
-    private int mElapsedTimeSteps;
-    private Random mRandom;
-    protected List<V> vertex_index;
-    protected int init_vertices;
-    protected Map<V,Integer> index_vertex;
-    protected Supplier<Graph<V,E>> graphFactory;
-    protected Supplier<V> vertexFactory;
-    protected Supplier<E> edgeFactory;
-    
-    /**
-     * Constructs a new instance of the generator.
-     * 
-     * @param graphFactory factory for graphs of the appropriate type
-     * @param vertexFactory factory for vertices of the appropriate type
-     * @param edgeFactory factory for edges of the appropriate type
-     * @param init_vertices     number of unconnected 'seed' vertices that the graph should start with
-     * @param numEdgesToAttach the number of edges that should be attached from the
-     * new vertex to pre-existing vertices at each time step
-     * @param seed  random number seed
-     * @param seedVertices storage for the seed vertices that this graph creates
-     */
-    // TODO: seedVertices is a bizarre way of exposing that information, refactor
-    public BarabasiAlbertGenerator(Supplier<Graph<V,E>> graphFactory,
-    		Supplier<V> vertexFactory, Supplier<E> edgeFactory, 
-    		int init_vertices, int numEdgesToAttach, 
-            int seed, Set<V> seedVertices)
-    {
-        Preconditions.checkArgument(init_vertices > 0,
-            "Number of initial unconnected 'seed' vertices must be positive");
-        Preconditions.checkArgument(numEdgesToAttach > 0, 
-            "Number of edges to attach at each time step must be positive");
-        
-        mNumEdgesToAttachPerStep = numEdgesToAttach;
-        mRandom = new Random(seed);
-        this.graphFactory = graphFactory;
-        this.vertexFactory = vertexFactory;
-        this.edgeFactory = edgeFactory;
-        this.init_vertices = init_vertices;
-        initialize(seedVertices);
-    }
-    
+public class BarabasiAlbertGenerator<V, E> implements EvolvingGraphGenerator<V, E> {
+	private Graph<V, E> mGraph = null;
+	private int mNumEdgesToAttachPerStep;
+	private int mElapsedTimeSteps;
+	private Random mRandom;
+	protected List<V> vertex_index;
+	protected int init_vertices;
+	protected Map<V, Integer> index_vertex;
+	protected Supplier<Graph<V, E>> graphFactory;
+	protected Supplier<V> vertexFactory;
+	protected Supplier<E> edgeFactory;
 
-    /**
-     * Constructs a new instance of the generator, whose output will be an undirected graph,
-     * and which will use the current time as a seed for the random number generation.
-     * 
-     * @param graphFactory factory for graphs of the appropriate type
-     * @param vertexFactory factory for vertices of the appropriate type
-     * @param edgeFactory factory for edges of the appropriate type
-     * @param init_vertices     number of vertices that the graph should start with
-     * @param numEdgesToAttach the number of edges that should be attached from the
-     * new vertex to pre-existing vertices at each time step
-     * @param seedVertices storage for the seed vertices that this graph creates
-     */
-    public BarabasiAlbertGenerator(Supplier<Graph<V,E>> graphFactory, 
-    		Supplier<V> vertexFactory, Supplier<E> edgeFactory,
-    		int init_vertices, int numEdgesToAttach, Set<V> seedVertices) {
-        this(graphFactory, vertexFactory, edgeFactory, init_vertices, numEdgesToAttach, (int) System.currentTimeMillis(), seedVertices);
-    }
-    
-    private void initialize(Set<V> seedVertices) {
-    	
-    	mGraph = graphFactory.get();
+	/**
+	 * Constructs a new instance of the generator.
+	 * 
+	 * @param graphFactory
+	 *            factory for graphs of the appropriate type
+	 * @param vertexFactory
+	 *            factory for vertices of the appropriate type
+	 * @param edgeFactory
+	 *            factory for edges of the appropriate type
+	 * @param init_vertices
+	 *            number of unconnected 'seed' vertices that the graph should
+	 *            start with
+	 * @param numEdgesToAttach
+	 *            the number of edges that should be attached from the new
+	 *            vertex to pre-existing vertices at each time step
+	 * @param seed
+	 *            random number seed
+	 * @param seedVertices
+	 *            storage for the seed vertices that this graph creates
+	 */
+	// TODO: seedVertices is a bizarre way of exposing that information,
+	// refactor
+	public BarabasiAlbertGenerator(Supplier<Graph<V, E>> graphFactory, Supplier<V> vertexFactory,
+			Supplier<E> edgeFactory, int init_vertices, int numEdgesToAttach, int seed, Set<V> seedVertices) {
+		Preconditions.checkArgument(init_vertices > 0,
+				"Number of initial unconnected 'seed' vertices must be positive");
+		Preconditions.checkArgument(numEdgesToAttach > 0,
+				"Number of edges to attach at each time step must be positive");
+		Preconditions.checkArgument(numEdgesToAttach <= init_vertices,
+				"Number of edges to attach at each time step must less than or equal to the number of initial vertices");
 
-        vertex_index = new ArrayList<V>(2*init_vertices);
-        index_vertex = new HashMap<V, Integer>(2*init_vertices);
-        for (int i = 0; i < init_vertices; i++) {
-            V v = vertexFactory.get();
-            mGraph.addVertex(v);
-            vertex_index.add(v);
-            index_vertex.put(v, i);
-            seedVertices.add(v);
-        }
-            
-        mElapsedTimeSteps = 0;
-    }
+		mNumEdgesToAttachPerStep = numEdgesToAttach;
+		mRandom = new Random(seed);
+		this.graphFactory = graphFactory;
+		this.vertexFactory = vertexFactory;
+		this.edgeFactory = edgeFactory;
+		this.init_vertices = init_vertices;
+		initialize(seedVertices);
+	}
 
-    private void createRandomEdge(Collection<V> preexistingNodes,
-    		V newVertex, Set<Pair<V>> added_pairs) {
-        V attach_point;
-        boolean created_edge = false;
-        Pair<V> endpoints;
-        do {
-            attach_point = vertex_index.get(mRandom.nextInt(vertex_index.size()));
-            
-            endpoints = new Pair<V>(newVertex, attach_point);
-            
-            // if parallel edges are not allowed, skip attach_point if <newVertex, attach_point>
-            // already exists; note that because of the way edges are added, we only need to check
-            // the list of candidate edges for duplicates.
-            if (!(mGraph instanceof MultiGraph))
-            {
-            	if (added_pairs.contains(endpoints))
-            		continue;
-            	if (mGraph.getDefaultEdgeType() == EdgeType.UNDIRECTED && 
-            		added_pairs.contains(new Pair<V>(attach_point, newVertex)))
-            		continue;
-            }
+	/**
+	 * Constructs a new instance of the generator, whose output will be an
+	 * undirected graph, and which will use the current time as a seed for the
+	 * random number generation.
+	 * 
+	 * @param graphFactory
+	 *            factory for graphs of the appropriate type
+	 * @param vertexFactory
+	 *            factory for vertices of the appropriate type
+	 * @param edgeFactory
+	 *            factory for edges of the appropriate type
+	 * @param init_vertices
+	 *            number of vertices that the graph should start with
+	 * @param numEdgesToAttach
+	 *            the number of edges that should be attached from the new
+	 *            vertex to pre-existing vertices at each time step
+	 * @param seedVertices
+	 *            storage for the seed vertices that this graph creates
+	 */
+	public BarabasiAlbertGenerator(Supplier<Graph<V, E>> graphFactory, Supplier<V> vertexFactory,
+			Supplier<E> edgeFactory, int init_vertices, int numEdgesToAttach, Set<V> seedVertices) {
+		this(graphFactory, vertexFactory, edgeFactory, init_vertices, numEdgesToAttach,
+				(int) System.currentTimeMillis(), seedVertices);
+	}
 
-            double degree = mGraph.inDegree(attach_point);
-            
-            // subtract 1 from numVertices because we don't want to count newVertex
-            // (which has already been added to the graph, but not to vertex_index)
-            double attach_prob = (degree + 1) / (mGraph.getEdgeCount() + mGraph.getVertexCount() - 1);
-            if (attach_prob >= mRandom.nextDouble())
-                created_edge = true;
-        }
-        while (!created_edge);
+	private void initialize(Set<V> seedVertices) {
+		mGraph = graphFactory.get();
 
-        added_pairs.add(endpoints);
-        
-        if (mGraph.getDefaultEdgeType() == EdgeType.UNDIRECTED) {
-        	added_pairs.add(new Pair<V>(attach_point, newVertex));
-        }
-    }
+		vertex_index = new ArrayList<V>(2 * init_vertices);
+		index_vertex = new HashMap<V, Integer>(2 * init_vertices);
+		for (int i = 0; i < init_vertices; i++) {
+			V v = vertexFactory.get();
+			mGraph.addVertex(v);
+			vertex_index.add(v);
+			index_vertex.put(v, i);
+			seedVertices.add(v);
+		}
 
-    public void evolveGraph(int numTimeSteps) {
+		mElapsedTimeSteps = 0;
+	}
 
-        for (int i = 0; i < numTimeSteps; i++) {
-            evolveGraph();
-            mElapsedTimeSteps++;
-        }
-    }
+	public void evolveGraph(int numTimeSteps) {
 
-    private void evolveGraph() {
-        Collection<V> preexistingNodes = mGraph.getVertices();
-        V newVertex = vertexFactory.get();
+		for (int i = 0; i < numTimeSteps; i++) {
+			evolveGraph();
+			mElapsedTimeSteps++;
+		}
+	}
 
-        mGraph.addVertex(newVertex);
+	private void evolveGraph() {
+		Collection<V> preexistingNodes = mGraph.getVertices();
+		V newVertex = vertexFactory.get();
 
-        // generate and store the new edges; don't add them to the graph
-        // yet because we don't want to bias the degree calculations
-        // (all new edges in a timestep should be added in parallel)
-        Set<Pair<V>> added_pairs = new HashSet<Pair<V>>(mNumEdgesToAttachPerStep*3);
-        
-        for (int i = 0; i < mNumEdgesToAttachPerStep; i++) 
-        	createRandomEdge(preexistingNodes, newVertex, added_pairs);
-        
-        for (Pair<V> pair : added_pairs)
-        {
-        	V v1 = pair.getFirst();
-        	V v2 = pair.getSecond();
-        	if (mGraph.getDefaultEdgeType() != EdgeType.UNDIRECTED || 
-        			!mGraph.isNeighbor(v1, v2))
-        		mGraph.addEdge(edgeFactory.get(), pair);
-        }
-        // now that we're done attaching edges to this new vertex, 
-        // add it to the index
-        vertex_index.add(newVertex);
-        index_vertex.put(newVertex, new Integer(vertex_index.size() - 1));
-    }
+		mGraph.addVertex(newVertex);
 
-    public int numIterations() {
-        return mElapsedTimeSteps;
-    }
+		// generate and store the new edges; don't add them to the graph
+		// yet because we don't want to bias the degree calculations
+		// (all new edges in a timestep should be added in parallel)
+		Set<Pair<V>> added_pairs = createRandomEdges(preexistingNodes, newVertex, mNumEdgesToAttachPerStep);
 
-    public Graph<V, E> get() {
-        return mGraph;
-    }
+		for (Pair<V> pair : added_pairs) {
+			V v1 = pair.getFirst();
+			V v2 = pair.getSecond();
+			if (mGraph.getDefaultEdgeType() != EdgeType.UNDIRECTED || !mGraph.isNeighbor(v1, v2))
+				mGraph.addEdge(edgeFactory.get(), pair);
+		}
+		// now that we're done attaching edges to this new vertex,
+		// add it to the index
+		vertex_index.add(newVertex);
+		index_vertex.put(newVertex, new Integer(vertex_index.size() - 1));
+	}
+
+	private Set<Pair<V>> createRandomEdges(Collection<V> preexistingNodes, V newVertex, int numEdges) {
+		Set<Pair<V>> added_pairs = new HashSet<Pair<V>>(numEdges * 3);
+
+		/* Generate the probability distribution */
+		Map<V, Double> item_weights = new HashMap<V, Double>();
+		for (V v : preexistingNodes) {
+			double degree;
+			double denominator;
+
+			/*
+			 * Attachment probability is dependent on whether the graph is
+			 * directed or undirected.
+			 * 
+			 * Subtract 1 from numVertices because we don't want to count
+			 * newVertex (which has already been added to the graph, but not to
+			 * vertex_index).
+			 */
+			if (mGraph.getDefaultEdgeType() == EdgeType.UNDIRECTED) {
+				degree = mGraph.degree(v);
+				denominator = (2 * mGraph.getEdgeCount()) + mGraph.getVertexCount() - 1;
+			} else {
+				degree = mGraph.inDegree(v);
+				denominator = mGraph.getEdgeCount() + mGraph.getVertexCount() - 1;
+			}
+
+			double prob = (degree + 1) / denominator;
+			item_weights.put(v, prob);
+		}
+		WeightedChoice<V> nodeProbabilities = new WeightedChoice<V>(item_weights, mRandom);
+
+		for (int i = 0; i < numEdges; i++) {
+			createRandomEdge(preexistingNodes, newVertex, added_pairs, nodeProbabilities);
+		}
+
+		return added_pairs;
+	}
+
+	private void createRandomEdge(Collection<V> preexistingNodes, V newVertex, Set<Pair<V>> added_pairs,
+			WeightedChoice<V> weightedProbabilities) {
+		V attach_point;
+		boolean created_edge = false;
+		Pair<V> endpoints;
+
+		do {
+			attach_point = weightedProbabilities.nextItem();
+
+			endpoints = new Pair<V>(newVertex, attach_point);
+
+			/*
+			 * If parallel edges are not allowed, skip attach_point if
+			 * <newVertex, attach_point> already exists; note that because of
+			 * the way the new node's edges are added, we only need to check the
+			 * list of candidate edges for duplicates.
+			 */
+			if (!(mGraph instanceof MultiGraph)) {
+				if (added_pairs.contains(endpoints))
+					continue;
+				if (mGraph.getDefaultEdgeType() == EdgeType.UNDIRECTED
+						&& added_pairs.contains(new Pair<V>(attach_point, newVertex)))
+					continue;
+			}
+			created_edge = true;
+		} while (!created_edge);
+
+		added_pairs.add(endpoints);
+
+		if (mGraph.getDefaultEdgeType() == EdgeType.UNDIRECTED) {
+			added_pairs.add(new Pair<V>(attach_point, newVertex));
+		}
+	}
+
+	public int numIterations() {
+		return mElapsedTimeSteps;
+	}
+
+	public Graph<V, E> get() {
+		return mGraph;
+	}
 }

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/generators/random/BarabasiAlbertGenerator.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/generators/random/BarabasiAlbertGenerator.java
@@ -78,6 +78,7 @@ import edu.uci.ics.jung.graph.util.Pair;
  * @author Scott White
  * @author Joshua O'Madadhain
  * @author Tom Nelson - adapted to jung2
+ * @author James Marchant
  */
 public class BarabasiAlbertGenerator<V, E> implements EvolvingGraphGenerator<V, E> {
 	private Graph<V, E> mGraph = null;

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/generators/random/BarabasiAlbertGenerator.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/generators/random/BarabasiAlbertGenerator.java
@@ -210,6 +210,14 @@ public class BarabasiAlbertGenerator<V, E> implements EvolvingGraphGenerator<V, 
 		/* Generate the probability distribution */
 		Map<V, Double> item_weights = new HashMap<V, Double>();
 		for (V v : preexistingNodes) {
+			/*
+			 * as preexistingNodes is a view onto the vertex set, it will
+			 * contain the new node. In the construction of Barabasi-Albert,
+			 * there should be no self-loops.
+			 */
+			if (v == newVertex)
+				continue;
+
 			double degree;
 			double denominator;
 

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/generators/random/TestBarabasiAlbert.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/generators/random/TestBarabasiAlbert.java
@@ -18,6 +18,8 @@ import edu.uci.ics.jung.graph.SparseGraph;
 import edu.uci.ics.jung.graph.SparseMultigraph;
 import edu.uci.ics.jung.graph.UndirectedSparseGraph;
 import edu.uci.ics.jung.graph.UndirectedSparseMultigraph;
+import edu.uci.ics.jung.graph.util.EdgeType;
+import edu.uci.ics.jung.graph.util.Pair;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -139,6 +141,42 @@ public class TestBarabasiAlbert extends TestCase {
 		graphFactory = new Supplier<Graph<Integer, Number>>() {
 			public Graph<Integer, Number> get() {
 				return new UndirectedSparseGraph<Integer, Number>();
+			}
+		};
+
+		generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory, edgeFactory, init_vertices,
+				edges_to_add_per_timestep, random_seed, num_tests);
+	}
+
+	/**
+	 * Due to the way the Barabasi-Albert algorithm works there should be no
+	 * opportunities for the generation of self-loops within the graph.
+	 */
+	public void testNoSelfLoops() {
+		graphFactory = new Supplier<Graph<Integer, Number>>() {
+			public Graph<Integer, Number> get() {
+				return new UndirectedSparseGraph<Integer, Number>() {
+					private static final long serialVersionUID = 1L;
+
+					/**
+					 * This anonymous class works as an UndirectedSparseGraph
+					 * but will not accept edges that connect a vertex to
+					 * itself.
+					 */
+					@Override
+					public boolean addEdge(Number edge, Pair<? extends Integer> endpoints, EdgeType edgeType) {
+						if (endpoints == null)
+							throw new IllegalArgumentException("endpoints may not be null");
+
+						Integer v1 = endpoints.getFirst();
+						Integer v2 = endpoints.getSecond();
+
+						if (v1.equals(v2))
+							throw new IllegalArgumentException("No self-loops");
+						else
+							return super.addEdge(edge, endpoints, edgeType);
+					}
+				};
 			}
 		};
 

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/generators/random/TestBarabasiAlbert.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/generators/random/TestBarabasiAlbert.java
@@ -6,61 +6,203 @@ package edu.uci.ics.jung.algorithms.generators.random;
 
 import java.util.HashSet;
 
+import com.google.common.base.Supplier;
+
+import edu.uci.ics.jung.graph.DirectedSparseGraph;
+import edu.uci.ics.jung.graph.DirectedSparseMultigraph;
+import edu.uci.ics.jung.graph.Graph;
+import edu.uci.ics.jung.graph.SparseGraph;
+import edu.uci.ics.jung.graph.SparseMultigraph;
+import edu.uci.ics.jung.graph.UndirectedSparseGraph;
+import edu.uci.ics.jung.graph.UndirectedSparseMultigraph;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
-import com.google.common.base.Supplier;
-
-import edu.uci.ics.jung.graph.Graph;
-import edu.uci.ics.jung.graph.SparseMultigraph;
-
-
 public class TestBarabasiAlbert extends TestCase {
+	protected Supplier<Graph<Integer, Number>> graphFactory;
+	protected Supplier<Integer> vertexFactory;
+	protected Supplier<Number> edgeFactory;
+
+	protected int init_vertices = 1;
+	protected int edges_to_add_per_timestep = 1;
+	protected int random_seed = 0;
+	protected int num_timesteps = 10;
+	protected int num_tests = 10;
+
 	public static Test suite() {
 		return new TestSuite(TestBarabasiAlbert.class);
 	}
 
 	@Override
-  protected void setUp() {
+	protected void setUp() {
+		graphFactory = new Supplier<Graph<Integer, Number>>() {
+			public Graph<Integer, Number> get() {
+				return new SparseMultigraph<Integer, Number>();
+			}
+		};
+		vertexFactory = new Supplier<Integer>() {
+			int count;
+
+			public Integer get() {
+				return count++;
+			}
+		};
+		edgeFactory = new Supplier<Number>() {
+			int count;
+
+			public Number get() {
+				return count++;
+			}
+		};
 	}
 
-	public void test() 
-    {
-        int init_vertices = 1;
-        int edges_to_add_per_timestep = 1;
-        int random_seed = 0;
-        int num_tests = 10;
-        int num_timesteps = 10;
-        
-        Supplier<Graph<Integer,Number>> graphFactory =
-        	new Supplier<Graph<Integer,Number>>() {
-        	public Graph<Integer,Number> get() {
-        		return new SparseMultigraph<Integer,Number>();
-        	}
-        };
-    	Supplier<Integer> vertexFactory = 
-    		new Supplier<Integer>() {
-    			int count;
-				public Integer get() {
-					return count++;
-				}};
-		Supplier<Number> edgeFactory = 
-		    new Supplier<Number>() {
-			    int count;
-				public Number get() {
-					return count++;
-				}};
+	private Graph<Integer, Number> generateAndTestSizeOfBarabasiAlbertGraph(
+			Supplier<Graph<Integer, Number>> graphFactory, Supplier<Integer> vertexFactory,
+			Supplier<Number> edgeFactory, int init_vertices, int edges_to_add_per_timestep, int random_seed,
+			int num_tests) {
+		BarabasiAlbertGenerator<Integer, Number> generator = new BarabasiAlbertGenerator<Integer, Number>(graphFactory,
+				vertexFactory, edgeFactory, init_vertices, edges_to_add_per_timestep, random_seed,
+				new HashSet<Integer>());
 
-	    BarabasiAlbertGenerator<Integer,Number> generator = 
-            new BarabasiAlbertGenerator<Integer,Number>(graphFactory, vertexFactory, edgeFactory,
-            		init_vertices,edges_to_add_per_timestep,random_seed, new HashSet<Integer>());
-	    for (int i = 1; i <= num_tests; i++) {
-	        
-	        generator.evolveGraph(num_timesteps);
-	        Graph<Integer, Number> graph = generator.get();
-	        assertEquals(graph.getVertexCount(), (i*num_timesteps) + init_vertices);
-	        assertEquals(graph.getEdgeCount(), edges_to_add_per_timestep * (i*num_timesteps));
-	    }
+		Graph<Integer, Number> graph = null;
+		// test the graph size over {@code num_tests} intervals of {@code
+		// num_timesteps} timesteps
+		for (int i = 1; i <= num_tests; i++) {
+			generator.evolveGraph(num_timesteps);
+			graph = generator.get();
+			assertEquals(graph.getVertexCount(), (i * num_timesteps) + init_vertices);
+			assertEquals(graph.getEdgeCount(), edges_to_add_per_timestep * (i * num_timesteps));
+		}
+
+		return graph;
+	}
+
+	public void testMultigraphCreation() {
+		generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory, edgeFactory, init_vertices,
+				edges_to_add_per_timestep, random_seed, num_tests);
+	}
+
+	public void testDirectedMultigraphCreation() {
+		graphFactory = new Supplier<Graph<Integer, Number>>() {
+			public Graph<Integer, Number> get() {
+				return new DirectedSparseMultigraph<Integer, Number>();
+			}
+		};
+
+		generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory, edgeFactory, init_vertices,
+				edges_to_add_per_timestep, random_seed, num_tests);
+	}
+
+	public void testUndirectedMultigraphCreation() {
+		graphFactory = new Supplier<Graph<Integer, Number>>() {
+			public Graph<Integer, Number> get() {
+				return new UndirectedSparseMultigraph<Integer, Number>();
+			}
+		};
+
+		generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory, edgeFactory, init_vertices,
+				edges_to_add_per_timestep, random_seed, num_tests);
+	}
+
+	public void testGraphCreation() {
+		graphFactory = new Supplier<Graph<Integer, Number>>() {
+			public Graph<Integer, Number> get() {
+				return new SparseGraph<Integer, Number>();
+			}
+		};
+
+		generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory, edgeFactory, init_vertices,
+				edges_to_add_per_timestep, random_seed, num_tests);
+	}
+
+	public void testDirectedGraphCreation() {
+		graphFactory = new Supplier<Graph<Integer, Number>>() {
+			public Graph<Integer, Number> get() {
+				return new DirectedSparseGraph<Integer, Number>();
+			}
+		};
+
+		generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory, edgeFactory, init_vertices,
+				edges_to_add_per_timestep, random_seed, num_tests);
+	}
+
+	public void testUndirectedGraphCreation() {
+		graphFactory = new Supplier<Graph<Integer, Number>>() {
+			public Graph<Integer, Number> get() {
+				return new UndirectedSparseGraph<Integer, Number>();
+			}
+		};
+
+		generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory, edgeFactory, init_vertices,
+				edges_to_add_per_timestep, random_seed, num_tests);
+	}
+
+	public void testPreconditions() {
+		// test init_vertices = 0
+		try {
+			generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory, edgeFactory, 0,
+					edges_to_add_per_timestep, random_seed, num_tests);
+			fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		// test negative init_vertices
+		try {
+			generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory, edgeFactory, -1,
+					edges_to_add_per_timestep, random_seed, num_tests);
+			fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		// test edges_to_add_per_timestep = 0
+		try {
+			generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory, edgeFactory, init_vertices, 0,
+					random_seed, num_tests);
+			fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		// test negative edges_to_add_per_timestep
+		try {
+			generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory, edgeFactory, init_vertices, -1,
+					random_seed, num_tests);
+			fail();
+		} catch (IllegalArgumentException e) {
+		}
+
+		// test edges_to_add_per_timestep > init_vertices
+		try {
+			generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory, edgeFactory, 2, 3, random_seed,
+					num_tests);
+			fail();
+		} catch (IllegalArgumentException e) {
+		}
+	}
+
+	/**
+	 * Every node should have an out-degree AT LEAST equal to the number of
+	 * edges added per timestep (dependent on if it is directed or undirected).
+	 */
+	public void testEveryNodeHasCorrectMinimumNumberOfEdges() {
+		Graph<Integer, Number> graph = generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory,
+				edgeFactory, init_vertices, edges_to_add_per_timestep, random_seed, num_tests);
+
+		for (Integer v : graph.getVertices()) {
+			assertTrue(graph.outDegree(v) >= edges_to_add_per_timestep);
+		}
+	}
+
+	/**
+	 * Check that not every edge goes to one node; the in-degree of any node
+	 * should be strictly less than the number of edges.
+	 */
+	public void testNotEveryEdgeToOneNode() {
+		Graph<Integer, Number> graph = generateAndTestSizeOfBarabasiAlbertGraph(graphFactory, vertexFactory,
+				edgeFactory, init_vertices, edges_to_add_per_timestep, random_seed, num_tests);
+
+		for (Integer v : graph.getVertices()) {
+			assertTrue(graph.inDegree(v) < graph.getEdgeCount());
+		}
 	}
 }

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/generators/random/TestBarabasiAlbert.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/generators/random/TestBarabasiAlbert.java
@@ -1,8 +1,11 @@
-package edu.uci.ics.jung.algorithms.generators.random;
-
-/**
- * @author W. Giordano, Scott White
+/*
+ * Copyright (c) 2016, the JUNG Project and the Regents of the University 
+ * of California.  All rights reserved.
+ *
+ * This software is open-source under the BSD license; see
+ * https://github.com/jrtom/jung/blob/master/LICENSE for a description.
  */
+package edu.uci.ics.jung.algorithms.generators.random;
 
 import java.util.HashSet;
 
@@ -19,6 +22,11 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
+/**
+ * @author W. Giordano
+ * @author Scott White
+ * @author James Marchant
+ */
 public class TestBarabasiAlbert extends TestCase {
 	protected Supplier<Graph<Integer, Number>> graphFactory;
 	protected Supplier<Integer> vertexFactory;


### PR DESCRIPTION
I have rewritten the Barabasi-Albert generator to address #32.

At the same time I took the opportunity to make some speed improvements under the hood. The previous implementation, when trying to create new edges, selected a potential node uniformly at random then compared nextDouble() to the attachment probability of this node. Whilst this has a small memory footprint and works well for small graphs it has scalability issues and larger graphs would take a long time to generate as the potential nodes could be selected and rejected many times for each successful choice.

With the inclusion of WeightedChoice in the JUNG util package this was the perfect candidate for replacing the previous method and the implementation instead now works out the correct weighted probabilities of attaching to each node and then simply makes choices for the correct number of edges needed within the timestep.

The speedup is drastic as can be seen below:

Nodes |Old Impl. (sec)|New Impl. (sec)|Speedup (%)
----:|:----:|:----:|:----:
 1000 |1.13|0.99|12%
 5000 |29.56|12.20|59%
 10000 |145.40|51.16|65%
 15000 |373.50|114.25|69%
 20000 |754.69|192.91|74%
 25000 |1145.61|315.92|72%

And comes at not a great cost to memory footprint (values are eye-balled from Visual VM).

Nodes | Old Impl. Avg (mb) |New Impl. Avg (mb) | Old Impl. Max (mb) | New Impl. Max (mb) |
----:|:----:|:----:|:----:|:----:
 1000| 120 | 60 | 290 | 120
 25000| 60 | 150 | 320 | 350

The reimplementation offers drastic speedups as well as fixing the previous bug and I hope it's of an acceptable quality that it might be included!

Additionally, I have enhanced and extended the Barabasi-Albert JUnit tests to test a number of new things (graph generation for different types, rough distribution checks) to hopefully ensure further changes are compliant.