### PR TITLE
EditingGraphMousePlugin: fix mousePressed

### DIFF
--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/control/EditingGraphMousePlugin.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/control/EditingGraphMousePlugin.java
@@ -87,7 +87,7 @@ public class EditingGraphMousePlugin<V,E> extends AbstractGraphMousePlugin imple
                 	this.createMode = Creating.EDGE;
                 	Graph<V,E> graph = vv.getModel().getGraphLayout().getGraph();
                 	// set default edge type
-                	EdgeType = graph.getDefaultEdgeType();
+                	EdgeType edgeType = graph.getDefaultEdgeType();
                     if((e.getModifiers() & MouseEvent.SHIFT_MASK) != 0
                     		&& graph instanceof UndirectedGraph == false) {
                         edgeType = EdgeType.DIRECTED;

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/control/EditingGraphMousePlugin.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/control/EditingGraphMousePlugin.java
@@ -78,8 +78,7 @@ public class EditingGraphMousePlugin<V,E> extends AbstractGraphMousePlugin imple
     @SuppressWarnings("unchecked")
 	public void mousePressed(MouseEvent e) {
         if(checkModifiers(e)) {
-            final VisualizationViewer<V,E> vv =
-                (VisualizationViewer<V,E>)e.getSource();
+            final VisualizationViewer<V,E> vv = (VisualizationViewer<V,E>)e.getSource();
             final Point2D p = e.getPoint();
             GraphElementAccessor<V,E> pickSupport = vv.getPickSupport();
             if(pickSupport != null) {
@@ -88,8 +87,7 @@ public class EditingGraphMousePlugin<V,E> extends AbstractGraphMousePlugin imple
                 	this.createMode = Creating.EDGE;
                 	Graph<V,E> graph = vv.getModel().getGraphLayout().getGraph();
                 	// set default edge type
-                	EdgeType edgeType = (graph instanceof DirectedGraph) ?
-                			EdgeType.DIRECTED : EdgeType.UNDIRECTED;
+                	EdgeType = graph.getDefaultEdgeType();
                     if((e.getModifiers() & MouseEvent.SHIFT_MASK) != 0
                     		&& graph instanceof UndirectedGraph == false) {
                         edgeType = EdgeType.DIRECTED;


### PR DESCRIPTION
Edge direction in mousePressed() had been defined in terms of the interface implemented (Directed/Undirected); now it correctly  uses the default edge type, which does the right thing for properly constructed delegate graphs.