### PR TITLE
migrate algorithms.blockmodel to common.graph

### DIFF
--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/blockmodel/StructurallyEquivalent.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/blockmodel/StructurallyEquivalent.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.base.Function;
+import com.google.common.graph.Graph;
 
-import edu.uci.ics.jung.graph.Graph;
 import edu.uci.ics.jung.graph.util.Pair;
 
 /**
@@ -41,9 +41,9 @@ import edu.uci.ics.jung.graph.util.Pair;
  * 
  * @author Danyel Fisher
  */
-public class StructurallyEquivalent<V,E> implements Function<Graph<V,E>, VertexPartition<V,E>> 
+public class StructurallyEquivalent<V> implements Function<Graph<V>, VertexPartition<V>> 
 {
-	public VertexPartition<V,E> apply(Graph<V,E> g) 
+	public VertexPartition<V> apply(Graph<V> g) 
 	{
 	    Set<Pair<V>> vertex_pairs = getEquivalentPairs(g);
 	    
@@ -65,7 +65,7 @@ public class StructurallyEquivalent<V,E> implements Function<Graph<V,E>, VertexP
 
         // pick up the vertices which don't appear in intermediate; they are
         // singletons (equivalence classes of size 1)
-        Collection<V> singletons = new ArrayList<V>(g.getVertices());
+        Collection<V> singletons = new ArrayList<V>(g.nodes());
         singletons.removeAll(intermediate.keySet());
         for (V v : singletons)
         {
@@ -74,7 +74,7 @@ public class StructurallyEquivalent<V,E> implements Function<Graph<V,E>, VertexP
             rv.add(v_set);
         }
 
-        return new VertexPartition<V, E>(g, intermediate, rv);
+        return new VertexPartition<V>(g, intermediate, rv);
 	}
 
 	/**
@@ -86,12 +86,12 @@ public class StructurallyEquivalent<V,E> implements Function<Graph<V,E>, VertexP
 	 * @return a Set of Pairs of vertices, where all the vertices in the inner
 	 * Pairs are equivalent.
 	 */
-	protected Set<Pair<V>> getEquivalentPairs(Graph<V,?> g) {
+	protected Set<Pair<V>> getEquivalentPairs(Graph<V> g) {
 
 		Set<Pair<V>> rv = new HashSet<Pair<V>>();
 		Set<V> alreadyEquivalent = new HashSet<V>();
 
-		List<V> l = new ArrayList<V>(g.getVertices());
+		List<V> l = new ArrayList<V>(g.nodes());
 
 		for (V v1 : l)
 		{
@@ -125,21 +125,21 @@ public class StructurallyEquivalent<V,E> implements Function<Graph<V,E>, VertexP
 	 * @return {@code true} if {@code v1}'s predecessors/successors are equal to
 	 *     {@code v2}'s predecessors/successors
 	 */
-	protected boolean isStructurallyEquivalent(Graph<V,?> g, V v1, V v2) {
+	protected boolean isStructurallyEquivalent(Graph<V> g, V v1, V v2) {
 		
-		if( g.degree(v1) != g.degree(v2)) {
+		if (g.degree(v1) != g.degree(v2)) {
 			return false;
 		}
 
-		Set<V> n1 = new HashSet<V>(g.getPredecessors(v1));
+		Set<V> n1 = new HashSet<V>(g.predecessors(v1));
 		n1.remove(v2);
 		n1.remove(v1);
-		Set<V> n2 = new HashSet<V>(g.getPredecessors(v2));
+		Set<V> n2 = new HashSet<V>(g.predecessors(v2));
 		n2.remove(v1);
 		n2.remove(v2);
 
-		Set<V> o1 = new HashSet<V>(g.getSuccessors(v1));
-		Set<V> o2 = new HashSet<V>(g.getSuccessors(v2));
+		Set<V> o1 = new HashSet<V>(g.successors(v1));
+		Set<V> o2 = new HashSet<V>(g.successors(v2));
 		o1.remove(v1);
 		o1.remove(v2);
 		o2.remove(v1);
@@ -151,10 +151,10 @@ public class StructurallyEquivalent<V,E> implements Function<Graph<V,E>, VertexP
 			return b;
 		
 		// if there's a directed edge v1->v2 then there's a directed edge v2->v1
-		b &= ( g.isSuccessor(v1, v2) == g.isSuccessor(v2, v1));
+		b &= (g.successors(v1).contains(v2) == g.successors(v2).contains(v1));
 		
 		// self-loop check
-		b &= ( g.isSuccessor(v1, v1) == g.isSuccessor(v2, v2));
+		b &= (g.successors(v1).contains(v1) == g.successors(v2).contains(v2));
 
 		return b;
 

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/blockmodel/VertexPartition.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/blockmodel/VertexPartition.java
@@ -12,10 +12,14 @@
  */
 package edu.uci.ics.jung.algorithms.blockmodel;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
-import edu.uci.ics.jung.graph.Graph;
-
+import com.google.common.graph.Graph;
 
 /**
  * Maintains information about a vertex partition of a graph.
@@ -23,11 +27,11 @@ import edu.uci.ics.jung.graph.Graph;
  * or from a collection of (disjoint) vertex sets,
  * such as those created by various clustering methods.
  */
-public class VertexPartition<V,E> 
+public class VertexPartition<V> 
 {
 	private Map<V,Set<V>> vertex_partition_map;
 	private Collection<Set<V>> vertex_sets;
-	private Graph<V,E> graph;
+	private Graph<V> graph;
 	
 	/**
 	 * Creates an instance based on the specified graph and mapping from vertices
@@ -35,7 +39,7 @@ public class VertexPartition<V,E>
 	 * @param g the graph over which the vertex partition is defined
 	 * @param partition_map the mapping from vertices to vertex sets (partitions)
 	 */
-	public VertexPartition(Graph<V,E> g, Map<V, Set<V>> partition_map) 
+	public VertexPartition(Graph<V> g, Map<V, Set<V>> partition_map) 
 	{
 		this.vertex_partition_map = Collections.unmodifiableMap(partition_map);
 		this.graph = g;
@@ -51,7 +55,7 @@ public class VertexPartition<V,E>
      * @param partition_map the mapping from vertices to vertex sets (partitions)
 	 * @param vertex_sets the set of disjoint vertex sets 
 	 */
-    public VertexPartition(Graph<V,E> g, Map<V, Set<V>> partition_map, 
+    public VertexPartition(Graph<V> g, Map<V, Set<V>> partition_map, 
     		Collection<Set<V>> vertex_sets) 
     {
         this.vertex_partition_map = Collections.unmodifiableMap(partition_map);
@@ -65,7 +69,7 @@ public class VertexPartition<V,E>
      * @param g the graph over which the vertex partition is defined
      * @param vertex_sets the set of disjoint vertex sets
      */
-    public VertexPartition(Graph<V,E> g, Collection<Set<V>> vertex_sets)
+    public VertexPartition(Graph<V> g, Collection<Set<V>> vertex_sets)
     {
         this.vertex_sets = vertex_sets;
         this.graph = g;
@@ -75,7 +79,7 @@ public class VertexPartition<V,E>
      * Returns the graph on which the partition is defined.
      * @return the graph on which the partition is defined
      */
-	public Graph<V,E> getGraph() 
+	public Graph<V> getGraph() 
 	{
 		return graph;
 	}

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/transformation/VertexPartitionCollapser.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/transformation/VertexPartitionCollapser.java
@@ -9,95 +9,66 @@
 */
 package edu.uci.ics.jung.algorithms.transformation;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
-import com.google.common.base.Supplier;
+import com.google.common.graph.EndpointPair;
+import com.google.common.graph.Graph;
+import com.google.common.graph.MutableValueGraph;
+import com.google.common.graph.ValueGraph;
+import com.google.common.graph.ValueGraphBuilder;
 
 import edu.uci.ics.jung.algorithms.blockmodel.VertexPartition;
-import edu.uci.ics.jung.graph.Graph;
 
 /**
  * This class transforms a graph with a known vertex partitioning into a graph whose 
- * vertices correspond to the input graph's partitions.  Two vertices in the output graph
- * are connected if and only if there exists at least one edge between vertices in the 
- * corresponding partitions of the input graph.  If the output graph permits parallel edges,
- * there will be an edge connecting two vertices in the new graph for each such 
- * edge connecting constituent vertices in the input graph.
+ * vertices correspond to the input graph's partitions
  * 
  * <p>Concept based on Danyel Fisher's <code>GraphCollapser</code> in JUNG 1.x.
- * 
  */
-public class VertexPartitionCollapser<V,E,CV,CE> 
+// TODO: add tests
+public class VertexPartitionCollapser 
 {
-    protected Supplier<Graph<CV,CE>> graph_factory;
-    protected Supplier<CV> vertex_factory;
-    protected Supplier<CE> edge_factory;
-    protected Map<Set<V>, CV> set_collapsedv;
-    
-    /**
-     * Creates an instance with the specified graph and element factories.
-     * @param vertex_factory used to construct the vertices of the new graph
-     * @param edge_factory used to construct the edges of the new graph
-     * @param graph_factory used to construct the new graph
-     */
-    public VertexPartitionCollapser(Supplier<Graph<CV,CE>> graph_factory, 
-            Supplier<CV> vertex_factory, Supplier<CE> edge_factory)
-    {
-        this.graph_factory = graph_factory;
-        this.vertex_factory = vertex_factory;
-        this.edge_factory = edge_factory;
-        this.set_collapsedv = new HashMap<Set<V>, CV>();
-    }
-
     /**
      * Creates a new graph whose vertices correspond to the partitions of the supplied graph.
+     * Two nodes u and v in the collapsed graph will be connected if there is an edge between
+     * any of the nodes in u and any of the nodes in v, and u and v are distinct.  The value
+     * of the edge represents the number of such edges.
      * @param partitioning a vertex partition of a graph
-     * @return a new graph whose vertices correspond to the partitions of the supplied graph
+     * @return the collapsed graph 
      */
-    public Graph<CV,CE> collapseVertexPartitions(VertexPartition<V,E> partitioning)
+    public static <V> ValueGraph<Set<V>, Integer> collapseVertexPartitions(
+    		VertexPartition<V> partitioning)
     {
-        Graph<V,E> original = partitioning.getGraph();
-        Graph<CV, CE> collapsed = graph_factory.get();
+        Graph<V> original = partitioning.getGraph();
+        ValueGraphBuilder<Object, Object> builder = original.isDirected()
+        		? ValueGraphBuilder.directed()
+        		: ValueGraphBuilder.undirected();
+        MutableValueGraph<Set<V>, Integer> collapsed = builder.build();
         
         // create vertices in new graph corresponding to equivalence sets in the original graph
         for (Set<V> set : partitioning.getVertexPartitions())
         {
-            CV cv = vertex_factory.get();
-            collapsed.addVertex(vertex_factory.get());
-            set_collapsedv.put(set, cv);
+        	collapsed.addNode(set);
         }
 
-        // create edges in new graph corresponding to edges in original graph
-        for (E e : original.getEdges())
-        {
-            Collection<V> incident = original.getIncidentVertices(e);
-            Collection<CV> collapsed_vertices = new HashSet<CV>();
-            Map<V, Set<V>> vertex_partitions = partitioning.getVertexToPartitionMap();
-            // collect the collapsed vertices corresponding to the original incident vertices
-            for (V v : incident)
-                collapsed_vertices.add(set_collapsedv.get(vertex_partitions.get(v))); 
-            // if there's only one collapsed vertex, continue (no edges to create)
-            if (collapsed_vertices.size() > 1)
-            {
-                CE ce = edge_factory.get();
-                collapsed.addEdge(ce, collapsed_vertices);
-            }
+        // for each pair of endpoints in the original graph, connect the corresponding nodes
+        // (representing partitions) in the collapsed graph if the partitions are different
+        Map<V, Set<V>> nodeToPartition = partitioning.getVertexToPartitionMap();
+        for (EndpointPair<V> endpoints : original.edges()) {
+        	V nodeU = endpoints.nodeU();
+        	V nodeV = endpoints.nodeV();
+        	Set<V> partitionU = nodeToPartition.get(nodeU);
+        	Set<V> partitionV = nodeToPartition.get(nodeV);
+        	if (nodeU.equals(nodeV) || partitionU.equals(partitionV)) {
+        		// we only connect partitions if the partitions are different;
+        		// check the nodes first as an optimization
+        		continue;
+        	}
+
+        	int edgeCount = collapsed.edgeValueOrDefault(partitionU, partitionV, 0);
+        	collapsed.putEdgeValue(partitionU, partitionV, edgeCount + 1);
         }
         return collapsed;
-    }
-    
-    /**
-     * @return a Function from vertex sets in the original graph to collapsed vertices
-     * in the transformed graph.
-     */
-    public Function<Set<V>, CV> getSetToCollapsedVertexTransformer()
-    {
-        return Functions.forMap(set_collapsedv);
     }
 }


### PR DESCRIPTION
Replaced JUNG Graph<V, E> with common.graph Graph<V>, or in one case a ValueGraph<V, Integer>.
Refactored VertexPartitionCollapser so that
- it doesn’t need factories
- the nodes of the collapsed graph are literally the partitions (Set<V>) of the original
We won’t necessarily leave it like this, but it’s a lot cleaner.  :)