### PR TITLE
Remove instruction to add classpath to manifest of built jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,17 +144,6 @@
           </configuration>
         </plugin>
         <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>${jar.plugin.version}</version>
-          <configuration>
-            <archive>
-              <manifest>
-                <addClasspath>true</addClasspath>
-              </manifest>
-            </archive>
-          </configuration>
-        </plugin>
-        <plugin>
           <artifactId>maven-release-plugin</artifactId>
           <version>{release.plugin.version}</version>
           <configuration>


### PR DESCRIPTION
This allows projects which use Gradle as their build tool to use the Error Prone javac compiler (via @tbroyer's gradle-errorprone-plugin), JUNG 2.2+ and the compiler options '-Xlint:all', '-Werror' together without any build errors.

Fixes issue #66.