### PR TITLE
Fix typo: "extendible" -> "extensible"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/jrtom/jung.svg?branch=master)](https://travis-ci.org/jrtom/jung)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/net.sf.jung/jung-algorithms/badge.svg)](https://maven-badges.herokuapp.com/maven-central/net.sf.jung/jung-algorithms)
 
-JUNG is a software library that provides a common and extendible language for the modeling, analysis, and visualization of
+JUNG is a software library that provides a common and extensible language for the modeling, analysis, and visualization of
 data that can be represented as a graph or network.  Its basis in Java allows JUNG-based applications to make use of the
 extensive built-in capabilities of the Java API, as well as those of other existing third-party Java libraries.
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   </scm>
   <description>
     JUNG the Java Universal Network/Graph Framework--is a software
-    library that provides a common and extendible language for the
+    library that provides a common and extensible language for the
     modeling, analysis, and visualization of data that can be
     represented as a graph or network. It is written in Java, which
     allows JUNG-based applications to make use of the extensive


### PR DESCRIPTION
This typo also exists in the website http://jrtom.github.io/jung/, but I don't know if changing the README.md or pom.xml affects it.