### PR TITLE
Replacing Guava's Function with the new java.util.function.Function

### DIFF
--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/blockmodel/StructurallyEquivalent.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/blockmodel/StructurallyEquivalent.java
@@ -10,7 +10,6 @@
  */
 package edu.uci.ics.jung.algorithms.blockmodel;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Graph;
 import edu.uci.ics.jung.graph.util.Pair;
 import java.util.ArrayList;
@@ -22,6 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Identifies sets of structurally equivalent vertices in a graph. Vertices <i> i</i> and <i>j</i>

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/cluster/BicomponentClusterer.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/cluster/BicomponentClusterer.java
@@ -9,7 +9,6 @@
  */
 package edu.uci.ics.jung.algorithms.cluster;
 
-import com.google.common.base.Function;
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.Graph;
 import java.util.HashMap;
@@ -18,6 +17,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
+import java.util.function.Function;
 
 /**
  * Finds all biconnected components (bicomponents) of an graph, <b>ignoring edge direction</b>. A

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/cluster/EdgeBetweennessClusterer.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/cluster/EdgeBetweennessClusterer.java
@@ -9,7 +9,6 @@
  */
 package edu.uci.ics.jung.algorithms.cluster;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.graph.Graphs;
 import com.google.common.graph.MutableNetwork;
@@ -17,6 +16,7 @@ import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.scoring.BetweennessCentrality;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * An algorithm for computing clusters (community structure) in graphs based on edge betweenness.

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/cluster/WeakComponentClusterer.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/cluster/WeakComponentClusterer.java
@@ -9,13 +9,13 @@
  */
 package edu.uci.ics.jung.algorithms.cluster;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Network;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Finds all weak components in a graph as sets of vertex sets. A weak component is defined as a

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/flows/EdmondsKarpMaxFlow.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/flows/EdmondsKarpMaxFlow.java
@@ -9,7 +9,6 @@
  */
 package edu.uci.ics.jung.algorithms.flows;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.graph.EndpointPair;
@@ -23,6 +22,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Implements the Edmonds-Karp maximum flow algorithm for solving the maximum flow problem. After

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/AbstractLayout.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/AbstractLayout.java
@@ -10,8 +10,6 @@
  */
 package edu.uci.ics.jung.algorithms.layout;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -22,6 +20,7 @@ import java.awt.geom.Point2D;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Abstract class for implementations of {@code Layout}. It handles some of the basic functions:
@@ -70,9 +69,8 @@ public abstract class AbstractLayout<N> implements Layout<N> {
    */
   protected AbstractLayout(Graph<N> graph, Function<N, Point2D> initializer) {
     this.nodes = graph.nodes();
-    Function<N, Point2D> chain =
-        Functions.<N, Point2D, Point2D>compose(p -> (Point2D) p.clone(), initializer);
-    this.locations = CacheBuilder.newBuilder().build(CacheLoader.from(chain));
+    Function<N, Point2D> chain = initializer.andThen(p -> (Point2D) p.clone());
+    this.locations = CacheBuilder.newBuilder().build(CacheLoader.from(chain::apply));
     initialized = true;
   }
 
@@ -97,9 +95,8 @@ public abstract class AbstractLayout<N> implements Layout<N> {
    */
   protected AbstractLayout(Graph<N> graph, Function<N, Point2D> initializer, Dimension size) {
     this.nodes = graph.nodes();
-    Function<N, Point2D> chain =
-        Functions.<N, Point2D, Point2D>compose(p -> (Point2D) p.clone(), initializer);
-    this.locations = CacheBuilder.newBuilder().build(CacheLoader.from(chain));
+    Function<N, Point2D> chain = initializer.andThen(p -> (Point2D) p.clone());
+    this.locations = CacheBuilder.newBuilder().build(CacheLoader.from(chain::apply));
     this.size = size;
   }
 
@@ -144,9 +141,8 @@ public abstract class AbstractLayout<N> implements Layout<N> {
     if (this.equals(initializer)) {
       throw new IllegalArgumentException("Layout cannot be initialized with itself");
     }
-    Function<N, Point2D> chain =
-        Functions.<N, Point2D, Point2D>compose(p -> (Point2D) p.clone(), initializer);
-    this.locations = CacheBuilder.newBuilder().build(CacheLoader.from(chain));
+    Function<N, Point2D> chain = initializer.andThen(p -> (Point2D) p.clone());
+    this.locations = CacheBuilder.newBuilder().build(CacheLoader.from(chain::apply));
     initialized = true;
   }
 

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/AggregateLayout.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/AggregateLayout.java
@@ -10,7 +10,6 @@
  */
 package edu.uci.ics.jung.algorithms.layout;
 
-import com.google.common.base.Function;
 import edu.uci.ics.jung.algorithms.util.IterativeContext;
 import java.awt.Dimension;
 import java.awt.geom.AffineTransform;
@@ -18,6 +17,7 @@ import java.awt.geom.Point2D;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * A {@code Layout} implementation that combines multiple other layouts so that they may be

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/Layout.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/Layout.java
@@ -9,10 +9,10 @@
  */
 package edu.uci.ics.jung.algorithms.layout;
 
-import com.google.common.base.Function;
 import java.awt.Dimension;
 import java.awt.geom.Point2D;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * A generalized interface for mechanisms that associate (x,y) coordinates with nodes.

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/LayoutDecorator.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/LayoutDecorator.java
@@ -10,10 +10,10 @@
 
 package edu.uci.ics.jung.algorithms.layout;
 
-import com.google.common.base.Function;
 import edu.uci.ics.jung.algorithms.util.IterativeContext;
 import java.awt.Dimension;
 import java.awt.geom.Point2D;
+import java.util.function.Function;
 
 /**
  * a pure decorator for the Layout interface. Intended to be overridden to provide specific behavior

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/SpringLayout.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/SpringLayout.java
@@ -7,8 +7,6 @@
  */
 package edu.uci.ics.jung.algorithms.layout;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -21,6 +19,7 @@ import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.geom.Point2D;
 import java.util.ConcurrentModificationException;
+import java.util.function.Function;
 
 /**
  * The SpringLayout package represents a visualization of a set of nodes. The SpringLayout, which is
@@ -41,13 +40,7 @@ public class SpringLayout<N> extends AbstractLayout<N> implements IterativeConte
   protected final Graph<N> graph;
 
   protected LoadingCache<N, SpringNodeData> springNodeData =
-      CacheBuilder.newBuilder()
-          .build(
-              new CacheLoader<N, SpringNodeData>() {
-                public SpringNodeData load(N node) {
-                  return new SpringNodeData();
-                }
-              });
+      CacheBuilder.newBuilder().build(CacheLoader.from(() -> new SpringNodeData()));
 
   /**
    * Constructor for a SpringLayout for a raw graph with associated dimension--the input knows how
@@ -56,7 +49,7 @@ public class SpringLayout<N> extends AbstractLayout<N> implements IterativeConte
    * @param g the graph on which the layout algorithm is to operate
    */
   public SpringLayout(Graph<N> g) {
-    this(g, Functions.<Integer>constant(30));
+    this(g, n -> 30);
   }
 
   /**

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/SpringLayout2.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/SpringLayout2.java
@@ -7,12 +7,12 @@
  */
 package edu.uci.ics.jung.algorithms.layout;
 
-import com.google.common.base.Function;
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.Graph;
 import java.awt.Dimension;
 import java.awt.geom.Point2D;
 import java.util.ConcurrentModificationException;
+import java.util.function.Function;
 
 /**
  * The SpringLayout package represents a visualization of a set of nodes. The SpringLayout, which is

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/StaticLayout.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/StaticLayout.java
@@ -11,10 +11,10 @@
  */
 package edu.uci.ics.jung.algorithms.layout;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Graph;
 import java.awt.Dimension;
 import java.awt.geom.Point2D;
+import java.util.function.Function;
 
 /**
  * StaticLayout places the nodes in the locations specified by its initializer, and has no other

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/TreeLayout.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/TreeLayout.java
@@ -10,7 +10,6 @@
 
 package edu.uci.ics.jung.algorithms.layout;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -26,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * @author Karlheinz Toni

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/util/RandomLocationTransformer.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/layout/util/RandomLocationTransformer.java
@@ -11,12 +11,12 @@
  */
 package edu.uci.ics.jung.algorithms.layout.util;
 
-import com.google.common.base.Function;
 import edu.uci.ics.jung.algorithms.layout.StaticLayout;
 import java.awt.Dimension;
 import java.awt.geom.Point2D;
 import java.util.Date;
 import java.util.Random;
+import java.util.function.Function;
 
 /**
  * Provides a random node location within the bounds of the Dimension property. This provides a

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/AbstractIterativeScorer.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/AbstractIterativeScorer.java
@@ -11,7 +11,6 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.scoring.util.DelegateToEdgeTransformer;
@@ -20,6 +19,7 @@ import edu.uci.ics.jung.algorithms.util.IterativeContext;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * An abstract class for algorithms that assign scores to vertices based on iterative methods.

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/AbstractIterativeScorerWithPriors.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/AbstractIterativeScorerWithPriors.java
@@ -11,8 +11,8 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Network;
+import java.util.function.Function;
 
 /**
  * An abstract class for iterative random-walk-based vertex scoring algorithms that have a fixed

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/BarycenterScorer.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/BarycenterScorer.java
@@ -11,10 +11,10 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Graph;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.shortestpath.Distance;
+import java.util.function.Function;
 
 /** Assigns scores to each vertex according to the sum of its distances to all other vertices. */
 public class BarycenterScorer<V, E> extends DistanceCentralityScorer<V, E> {

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/BetweennessCentrality.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/BetweennessCentrality.java
@@ -10,8 +10,6 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.util.MapBinaryHeap;
 import java.util.ArrayList;
@@ -22,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Stack;
+import java.util.function.Function;
 
 /**
  * Computes betweenness centrality for each vertex and edge in the graph.
@@ -42,7 +41,7 @@ public class BetweennessCentrality<V, E> implements VertexScorer<V, Double>, Edg
    */
   public BetweennessCentrality(Network<V, E> graph) {
     initialize(graph);
-    computeBetweenness(new LinkedList<V>(), Functions.<Integer>constant(1));
+    computeBetweenness(new LinkedList<V>(), n -> 1);
   }
 
   /**

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/ClosenessCentrality.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/ClosenessCentrality.java
@@ -11,10 +11,10 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Graph;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.shortestpath.Distance;
+import java.util.function.Function;
 
 /**
  * Assigns scores to each vertex based on the mean distance to each other vertex.

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/DistanceCentralityScorer.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/DistanceCentralityScorer.java
@@ -11,7 +11,6 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Maps;
 import com.google.common.graph.Graph;
 import com.google.common.graph.Network;
@@ -20,6 +19,7 @@ import edu.uci.ics.jung.algorithms.shortestpath.Distance;
 import edu.uci.ics.jung.algorithms.shortestpath.UnweightedShortestPath;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Assigns scores to vertices based on their distances to each other vertex in the graph.

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/EigenvectorCentrality.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/EigenvectorCentrality.java
@@ -11,8 +11,8 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Network;
+import java.util.function.Function;
 
 /**
  * Calculates eigenvector centrality for each vertex in the graph. The 'eigenvector centrality' for

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/HITS.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/HITS.java
@@ -11,9 +11,9 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.scoring.util.ScoringUtils;
+import java.util.function.Function;
 
 /**
  * Assigns hub and authority scores to each vertex depending on the topology of the network. The

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/HITSWithPriors.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/HITSWithPriors.java
@@ -11,9 +11,8 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.graph.Network;
+import java.util.function.Function;
 
 /**
  * A generalization of HITS that permits non-uniformly-distributed random jumps. The 'vertex_priors'
@@ -58,7 +57,7 @@ public class HITSWithPriors<V, E> extends AbstractIterativeScorerWithPriors<V, E
    * @param alpha the probability of a random jump at each step
    */
   public HITSWithPriors(Network<V, E> g, Function<V, HITS.Scores> vertex_priors, double alpha) {
-    super(g, Functions.constant(1.0), vertex_priors, alpha);
+    super(g, n -> 1.0, vertex_priors, alpha);
     disappearing_potential = new HITS.Scores(0, 0);
   }
 

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/KStepMarkov.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/KStepMarkov.java
@@ -8,9 +8,9 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.scoring.util.ScoringUtils;
+import java.util.function.Function;
 
 /**
  * A special case of {@code PageRankWithPriors} in which the final scores represent a probability

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/PageRank.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/PageRank.java
@@ -11,9 +11,9 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.scoring.util.ScoringUtils;
+import java.util.function.Function;
 
 /**
  * Assigns scores to each vertex according to the PageRank algorithm.

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/PageRankWithPriors.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/PageRankWithPriors.java
@@ -11,9 +11,9 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.scoring.util.UniformDegreeWeight;
+import java.util.function.Function;
 
 /**
  * A generalization of PageRank that permits non-uniformly-distributed random jumps. The

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/VoltageScorer.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/VoltageScorer.java
@@ -11,7 +11,6 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -21,6 +20,7 @@ import edu.uci.ics.jung.algorithms.scoring.util.UniformDegreeWeight;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Assigns scores to vertices according to their 'voltage' in an approximate solution to the

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/util/DelegateToEdgeTransformer.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/util/DelegateToEdgeTransformer.java
@@ -11,7 +11,7 @@
  */
 package edu.uci.ics.jung.algorithms.scoring.util;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 /**
  * A {@code Transformer<VEPair,Number} that delegates its operation to a {@code

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/util/ScoringUtils.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/util/ScoringUtils.java
@@ -11,9 +11,9 @@
  */
 package edu.uci.ics.jung.algorithms.scoring.util;
 
-import com.google.common.base.Function;
 import edu.uci.ics.jung.algorithms.scoring.HITS;
 import java.util.Collection;
+import java.util.function.Function;
 
 /**
  * Methods for assigning values (to be interpreted as prior probabilities) to vertices in the

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/util/UniformDegreeWeight.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/util/UniformDegreeWeight.java
@@ -8,8 +8,8 @@
  */
 package edu.uci.ics.jung.algorithms.scoring.util;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Network;
+import java.util.function.Function;
 
 /**
  * An edge weight function that assigns weights as uniform transition probabilities:

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/util/VertexScoreTransformer.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/scoring/util/VertexScoreTransformer.java
@@ -11,8 +11,8 @@
  */
 package edu.uci.ics.jung.algorithms.scoring.util;
 
-import com.google.common.base.Function;
 import edu.uci.ics.jung.algorithms.scoring.VertexScorer;
+import java.util.function.Function;
 
 /** A Function convenience wrapper around VertexScorer. */
 public class VertexScoreTransformer<V, S> implements Function<V, S> {

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/shortestpath/DijkstraDistance.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/shortestpath/DijkstraDistance.java
@@ -11,8 +11,6 @@
  */
 package edu.uci.ics.jung.algorithms.shortestpath;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.util.MapBinaryHeap;
@@ -24,6 +22,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Calculates distances in a specified graph, using Dijkstra's single-source-shortest-path
@@ -98,7 +97,7 @@ public class DijkstraDistance<V, E> implements Distance<V> {
    * @param g the graph on which distances will be calculated
    */
   public DijkstraDistance(Network<V, E> g) {
-    this(g, Functions.constant(1), true);
+    this(g, e -> 1, true);
   }
 
   /**
@@ -109,7 +108,7 @@ public class DijkstraDistance<V, E> implements Distance<V> {
    * @param cached specifies whether the results are to be cached
    */
   public DijkstraDistance(Network<V, E> g, boolean cached) {
-    this(g, Functions.constant(1), cached);
+    this(g, e -> 1, cached);
   }
 
   /**

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/shortestpath/DijkstraShortestPath.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/shortestpath/DijkstraShortestPath.java
@@ -9,7 +9,6 @@
  */
 package edu.uci.ics.jung.algorithms.shortestpath;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.graph.Network;
 import java.util.HashMap;
@@ -19,6 +18,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Calculates distances and shortest paths using Dijkstra's single-source-shortest-path algorithm.

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/shortestpath/DistanceStatistics.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/shortestpath/DistanceStatistics.java
@@ -9,12 +9,12 @@
  */
 package edu.uci.ics.jung.algorithms.shortestpath;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Graph;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.scoring.ClosenessCentrality;
 import edu.uci.ics.jung.algorithms.scoring.util.VertexScoreTransformer;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Statistics relating to vertex-vertex distances in a graph.

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/shortestpath/MinimumSpanningTree.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/shortestpath/MinimumSpanningTree.java
@@ -1,6 +1,5 @@
 package edu.uci.ics.jung.algorithms.shortestpath;
 
-import com.google.common.base.Function;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.MutableValueGraph;
 import com.google.common.graph.Network;
@@ -12,6 +11,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Creates a minimum spanning tree of a specified graph using a variation of Prim's algorithm.

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/util/SettableTransformer.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/util/SettableTransformer.java
@@ -11,7 +11,7 @@
  */
 package edu.uci.ics.jung.algorithms.util;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 /**
  * An interface for classes that can set the value to be returned (from <code>transform()</code>)

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/flows/TestEdmondsKarpMaxFlow.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/flows/TestEdmondsKarpMaxFlow.java
@@ -9,7 +9,6 @@
  */
 package edu.uci.ics.jung.algorithms.flows;
 
-import com.google.common.base.Functions;
 import com.google.common.base.Supplier;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.NetworkBuilder;
@@ -110,12 +109,7 @@ public class TestEdmondsKarpMaxFlow extends TestCase {
 
     EdmondsKarpMaxFlow<Number, Number> ek =
         new EdmondsKarpMaxFlow<Number, Number>(
-            graph,
-            0,
-            5,
-            Functions.<Number, Integer>forMap(edgeCapacityMap, null),
-            edgeFlowMap,
-            edgeFactory);
+            graph, 0, 5, n -> edgeCapacityMap.get(n), edgeFlowMap, edgeFactory);
     ek.evaluate();
 
     assertTrue(ek.getMaxFlow() == 23);
@@ -190,12 +184,7 @@ public class TestEdmondsKarpMaxFlow extends TestCase {
 
     EdmondsKarpMaxFlow<Number, Number> ek =
         new EdmondsKarpMaxFlow<Number, Number>(
-            graph,
-            0,
-            5,
-            Functions.<Number, Integer>forMap(edgeCapacityMap, null),
-            edgeFlowMap,
-            edgeFactory);
+            graph, 0, 5, n -> edgeCapacityMap.get(n), edgeFlowMap, edgeFactory);
     ek.evaluate();
 
     assertTrue(ek.getMaxFlow() == 7);

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/scoring/TestBetweennessCentrality.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/scoring/TestBetweennessCentrality.java
@@ -8,9 +8,9 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Function;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.NetworkBuilder;
+import java.util.function.Function;
 import junit.framework.TestCase;
 
 /** */

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/scoring/TestKStepMarkov.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/scoring/TestKStepMarkov.java
@@ -1,6 +1,5 @@
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Functions;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.NetworkBuilder;
 import edu.uci.ics.jung.algorithms.scoring.util.ScoringUtils;
@@ -44,7 +43,7 @@ public class TestKStepMarkov extends TestCase {
     priors.add(2);
     KStepMarkov<Number, Number> ranker =
         new KStepMarkov<Number, Number>(
-            mGraph, Functions.forMap(edgeWeights), ScoringUtils.getUniformRootPrior(priors), 2);
+            mGraph, e -> edgeWeights.get(e), ScoringUtils.getUniformRootPrior(priors), 2);
     //        ranker.evaluate();
     //        System.out.println(ranker.getIterations());
 

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/scoring/TestPageRank.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/scoring/TestPageRank.java
@@ -9,7 +9,6 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Functions;
 import com.google.common.base.Supplier;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.NetworkBuilder;
@@ -59,8 +58,7 @@ public class TestPageRank extends TestCase {
     addEdge(3, 1, 1.0);
     addEdge(2, 1, 0.5);
 
-    PageRank<Integer, Integer> pr =
-        new PageRank<Integer, Integer>(graph, Functions.forMap(edgeWeights), 0);
+    PageRank<Integer, Integer> pr = new PageRank<Integer, Integer>(graph, edgeWeights::get, 0);
     pr.evaluate();
 
     Assert.assertEquals(pr.getVertexScore(0), 0.0, pr.getTolerance());

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/scoring/TestVoltageScore.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/scoring/TestVoltageScore.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.algorithms.scoring;
 
-import com.google.common.base.Functions;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.NetworkBuilder;
 import junit.framework.TestCase;
@@ -34,7 +33,7 @@ public class TestVoltageScore extends TestCase {
     g.addEdge(4, 1, j++);
     g.addEdge(4, 0, j++);
 
-    VoltageScorer<Number, Number> vr = new VoltageScorer<>(g, Functions.constant(1), 0, 3);
+    VoltageScorer<Number, Number> vr = new VoltageScorer<>(g, n -> 1, 0, 3);
     double[] voltages = {1.0, 2.0 / 3, 2.0 / 3, 0, 1.0 / 3};
 
     vr.evaluate();
@@ -52,7 +51,7 @@ public class TestVoltageScore extends TestCase {
     g.addEdge(3, 5, j++);
     g.addEdge(4, 6, j++);
     g.addEdge(5, 6, j++);
-    VoltageScorer<Number, Number> vr = new VoltageScorer<>(g, Functions.constant(1), 0, 6);
+    VoltageScorer<Number, Number> vr = new VoltageScorer<>(g, n -> 1, 0, 6);
     double[] voltages = {1.0, 0.75, 0.75, 0.5, 0.25, 0.25, 0};
 
     vr.evaluate();

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/shortestpath/TestShortestPath.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/shortestpath/TestShortestPath.java
@@ -4,8 +4,6 @@
  */
 package edu.uci.ics.jung.algorithms.shortestpath;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.base.Supplier;
 import com.google.common.collect.BiMap;
 import com.google.common.graph.MutableNetwork;
@@ -19,6 +17,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import junit.framework.TestCase;
 
 /** @author Joshua O'Madadhain */
@@ -481,7 +480,7 @@ public class TestShortestPath extends TestCase {
   @Override
   protected void setUp() {
     edgeWeights = new HashMap<Integer, Number>();
-    nev = Functions.<Integer, Number>forMap(edgeWeights);
+    nev = edgeWeights::get;
     dg = NetworkBuilder.directed().allowsParallelEdges(true).allowsSelfLoops(true).build();
     for (int i = 0; i < dg_distances.length; i++) {
       dg.addNode(vertexFactoryDG.get());

--- a/jung-io/src/main/java/edu/uci/ics/jung/io/GraphMLMetadata.java
+++ b/jung-io/src/main/java/edu/uci/ics/jung/io/GraphMLMetadata.java
@@ -8,7 +8,7 @@
  */
 package edu.uci.ics.jung.io;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 /**
  * Maintains information relating to data for the specified type. This includes a Function from

--- a/jung-io/src/main/java/edu/uci/ics/jung/io/GraphMLWriter.java
+++ b/jung-io/src/main/java/edu/uci/ics/jung/io/GraphMLWriter.java
@@ -11,8 +11,6 @@
  */
 package edu.uci.ics.jung.io;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.Network;
 import java.io.BufferedWriter;
@@ -21,6 +19,7 @@ import java.io.Writer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Writes graphs out in GraphML format.
@@ -45,19 +44,14 @@ public class GraphMLWriter<V, E> {
   protected int nest_level;
 
   public GraphMLWriter() {
-    vertex_ids =
-        new Function<V, String>() {
-          public String apply(V v) {
-            return v.toString();
-          }
-        };
-    edge_ids = Functions.constant(null);
+    vertex_ids = V::toString;
+    edge_ids = e -> null;
     graph_data = Collections.emptyMap();
     vertex_data = Collections.emptyMap();
     edge_data = Collections.emptyMap();
-    vertex_desc = Functions.constant(null);
-    edge_desc = Functions.constant(null);
-    graph_desc = Functions.constant(null);
+    vertex_desc = n -> null;
+    edge_desc = e -> null;
+    graph_desc = g -> null;
     nest_level = 0;
   }
 

--- a/jung-io/src/main/java/edu/uci/ics/jung/io/PajekNetWriter.java
+++ b/jung-io/src/main/java/edu/uci/ics/jung/io/PajekNetWriter.java
@@ -11,7 +11,6 @@
  */
 package edu.uci.ics.jung.io;
 
-import com.google.common.base.Function;
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.Network;
 import java.awt.geom.Point2D;
@@ -21,6 +20,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Writes graphs in the Pajek NET format.

--- a/jung-io/src/main/java/edu/uci/ics/jung/io/graphml/GraphMLReader2.java
+++ b/jung-io/src/main/java/edu/uci/ics/jung/io/graphml/GraphMLReader2.java
@@ -10,7 +10,6 @@
 
 package edu.uci.ics.jung.io.graphml;
 
-import com.google.common.base.Function;
 import com.google.common.graph.MutableNetwork;
 import edu.uci.ics.jung.io.GraphIOException;
 import edu.uci.ics.jung.io.GraphReader;
@@ -19,6 +18,7 @@ import edu.uci.ics.jung.io.graphml.parser.GraphMLEventFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.util.function.Function;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;

--- a/jung-io/src/main/java/edu/uci/ics/jung/io/graphml/parser/ElementParserRegistry.java
+++ b/jung-io/src/main/java/edu/uci/ics/jung/io/graphml/parser/ElementParserRegistry.java
@@ -10,7 +10,6 @@
 
 package edu.uci.ics.jung.io.graphml.parser;
 
-import com.google.common.base.Function;
 import com.google.common.graph.MutableNetwork;
 import edu.uci.ics.jung.io.graphml.EdgeMetadata;
 import edu.uci.ics.jung.io.graphml.GraphMLConstants;
@@ -19,6 +18,7 @@ import edu.uci.ics.jung.io.graphml.KeyMap;
 import edu.uci.ics.jung.io.graphml.NodeMetadata;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Registry for all element parsers.

--- a/jung-io/src/main/java/edu/uci/ics/jung/io/graphml/parser/ParserContext.java
+++ b/jung-io/src/main/java/edu/uci/ics/jung/io/graphml/parser/ParserContext.java
@@ -10,12 +10,12 @@
 
 package edu.uci.ics.jung.io.graphml.parser;
 
-import com.google.common.base.Function;
 import com.google.common.graph.MutableNetwork;
 import edu.uci.ics.jung.io.graphml.EdgeMetadata;
 import edu.uci.ics.jung.io.graphml.GraphMetadata;
 import edu.uci.ics.jung.io.graphml.KeyMap;
 import edu.uci.ics.jung.io.graphml.NodeMetadata;
+import java.util.function.Function;
 
 /**
  * Provides resources related to the current parsing context.

--- a/jung-io/src/test/java/edu/uci/ics/jung/io/PajekNetIOTest.java
+++ b/jung-io/src/test/java/edu/uci/ics/jung/io/PajekNetIOTest.java
@@ -11,7 +11,6 @@
  */
 package edu.uci.ics.jung.io;
 
-import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
@@ -24,6 +23,7 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
 import junit.framework.Assert;
 import junit.framework.TestCase;
 

--- a/jung-io/src/test/java/edu/uci/ics/jung/io/TestGraphMLReader.java
+++ b/jung-io/src/test/java/edu/uci/ics/jung/io/TestGraphMLReader.java
@@ -9,7 +9,6 @@
  */
 package edu.uci.ics.jung.io;
 
-import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.collect.BiMap;
 import com.google.common.graph.MutableNetwork;
@@ -20,6 +19,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Function;
 import javax.xml.parsers.ParserConfigurationException;
 import junit.framework.Assert;
 import junit.framework.Test;

--- a/jung-io/src/test/java/edu/uci/ics/jung/io/TestGraphMLWriter.java
+++ b/jung-io/src/test/java/edu/uci/ics/jung/io/TestGraphMLWriter.java
@@ -11,8 +11,6 @@
  */
 package edu.uci.ics.jung.io;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
@@ -26,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import javax.xml.parsers.ParserConfigurationException;
 import junit.framework.Assert;
 import junit.framework.TestCase;
@@ -42,7 +41,7 @@ public class TestGraphMLWriter extends TestCase {
           }
         };
 
-    Function<String, String> vertex_name = Functions.identity();
+    Function<String, String> vertex_name = Function.identity();
     //TransformerUtils.nopTransformer();
 
     gmlw.addEdgeData("weight", "integer value for the edge", Integer.toString(-1), edge_weight);

--- a/jung-io/src/test/java/edu/uci/ics/jung/io/graphml/DummyEdge.java
+++ b/jung-io/src/test/java/edu/uci/ics/jung/io/graphml/DummyEdge.java
@@ -1,6 +1,6 @@
 package edu.uci.ics.jung.io.graphml;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 public class DummyEdge extends DummyGraphObjectBase {
 

--- a/jung-io/src/test/java/edu/uci/ics/jung/io/graphml/DummyGraphObjectBase.java
+++ b/jung-io/src/test/java/edu/uci/ics/jung/io/graphml/DummyGraphObjectBase.java
@@ -1,8 +1,8 @@
 package edu.uci.ics.jung.io.graphml;
 
-import com.google.common.base.Function;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.NetworkBuilder;
+import java.util.function.Function;
 
 // TODO: replace common.base.Function with java.util.Function
 public class DummyGraphObjectBase {

--- a/jung-io/src/test/java/edu/uci/ics/jung/io/graphml/DummyVertex.java
+++ b/jung-io/src/test/java/edu/uci/ics/jung/io/graphml/DummyVertex.java
@@ -1,6 +1,6 @@
 package edu.uci.ics.jung.io.graphml;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 public class DummyVertex extends DummyGraphObjectBase {
 

--- a/jung-io/src/test/java/edu/uci/ics/jung/io/graphml/TestGraphMLReader2.java
+++ b/jung-io/src/test/java/edu/uci/ics/jung/io/graphml/TestGraphMLReader2.java
@@ -10,7 +10,6 @@
 
 package edu.uci.ics.jung.io.graphml;
 
-import com.google.common.base.Function;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.io.GraphIOException;
@@ -22,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Function;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/AddNodeDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/AddNodeDemo.java
@@ -10,7 +10,6 @@
 
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Functions;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.NetworkBuilder;
 import edu.uci.ics.jung.algorithms.layout.AbstractLayout;
@@ -126,8 +125,7 @@ public class AddNodeDemo extends javax.swing.JApplet {
             Dimension d = new Dimension(600, 600);
             if (switchLayout.getText().indexOf("Spring") > 0) {
               switchLayout.setText("Switch to FRLayout");
-              layout =
-                  new SpringLayout<Number>(g.asGraph(), Functions.<Integer>constant(EDGE_LENGTH));
+              layout = new SpringLayout<Number>(g.asGraph(), e -> EDGE_LENGTH);
               layout.setSize(d);
               vv.getModel().setGraphLayout(layout, d);
               Layout<Number> delegateLayout =

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/AnimatingAddNodeDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/AnimatingAddNodeDemo.java
@@ -9,7 +9,6 @@
 
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Functions;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.NetworkBuilder;
 import edu.uci.ics.jung.algorithms.layout.AbstractLayout;
@@ -131,7 +130,7 @@ public class AnimatingAddNodeDemo extends javax.swing.JApplet {
             Dimension d = vv.getSize(); //new Dimension(600,600);
             if (switchLayout.getText().indexOf("Spring") > 0) {
               switchLayout.setText("Switch to FRLayout");
-              layout = new SpringLayout<Number>(g.asGraph(), Functions.constant(EDGE_LENGTH));
+              layout = new SpringLayout<Number>(g.asGraph(), e -> EDGE_LENGTH);
               layout.setSize(d);
               Relaxer relaxer = new VisRunner((IterativeContext) layout);
               relaxer.stop();

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/BalloonLayoutDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/BalloonLayoutDemo.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Functions;
 import edu.uci.ics.jung.algorithms.layout.BalloonLayout;
 import edu.uci.ics.jung.algorithms.layout.TreeLayout;
 import edu.uci.ics.jung.graph.CTreeNetwork;
@@ -39,7 +38,6 @@ import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GridLayout;
-import java.awt.Paint;
 import java.awt.Shape;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -96,7 +94,7 @@ public class BalloonLayoutDemo extends JApplet {
     vv.getRenderContext().setVertexLabelTransformer(new ToStringLabeller());
     // add a listener for ToolTips
     vv.setVertexToolTipTransformer(new ToStringLabeller());
-    vv.getRenderContext().setArrowFillPaintTransformer(Functions.<Paint>constant(Color.lightGray));
+    vv.getRenderContext().setArrowFillPaintTransformer(a -> Color.lightGray);
     rings = new Rings(radialLayout);
 
     Container content = getContentPane();

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/ClusteringDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/ClusteringDemo.java
@@ -9,7 +9,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Functions;
 import com.google.common.base.Supplier;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -74,9 +73,9 @@ public class ClusteringDemo extends JApplet {
   VisualizationViewer<Number, Number> vv;
 
   LoadingCache<Number, Paint> vertexPaints =
-      CacheBuilder.newBuilder().build(CacheLoader.from(Functions.<Paint>constant(Color.white)));
+      CacheBuilder.newBuilder().build(CacheLoader.from(() -> Color.white));
   LoadingCache<Number, Paint> edgePaints =
-      CacheBuilder.newBuilder().build(CacheLoader.from(Functions.<Paint>constant(Color.blue)));
+      CacheBuilder.newBuilder().build(CacheLoader.from(() -> Color.blue));
 
   private static final Stroke THIN = new BasicStroke(1);
   private static final Stroke THICK = new BasicStroke(2);

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/DemoLensVertexImageShaperDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/DemoLensVertexImageShaperDemo.java
@@ -8,8 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
@@ -48,6 +46,7 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 import javax.swing.BorderFactory;
 import javax.swing.ButtonGroup;
 import javax.swing.Icon;
@@ -157,7 +156,7 @@ public class DemoLensVertexImageShaperDemo extends JApplet {
         new VertexIconShapeTransformer<Integer>(new EllipseVertexShapeTransformer<Integer>());
     vertexImageShapeFunction.setIconMap(iconMap);
 
-    final Function<Integer, Icon> vertexIconFunction = Functions.forMap(iconMap);
+    final Function<Integer, Icon> vertexIconFunction = iconMap::get;
 
     vv.getRenderContext().setVertexShapeTransformer(vertexImageShapeFunction);
     vv.getRenderContext().setVertexIconTransformer(vertexIconFunction);

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/DrawnIconVertexDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/DrawnIconVertexDemo.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
@@ -30,6 +29,7 @@ import java.awt.Container;
 import java.awt.Graphics;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.function.Function;
 import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JFrame;

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/EdgeLabelDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/EdgeLabelDemo.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
@@ -37,6 +36,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.util.function.Function;
 import javax.swing.AbstractButton;
 import javax.swing.BorderFactory;
 import javax.swing.BoundedRangeModel;

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/GraphEditorDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/GraphEditorDemo.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.NetworkBuilder;
@@ -34,6 +33,7 @@ import java.awt.image.BufferedImage;
 import java.awt.print.Printable;
 import java.awt.print.PrinterJob;
 import java.io.File;
+import java.util.function.Function;
 import javax.imageio.ImageIO;
 import javax.swing.AbstractAction;
 import javax.swing.JApplet;

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/GraphFromGraphMLDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/GraphFromGraphMLDemo.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.NetworkBuilder;
@@ -33,6 +32,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.io.IOException;
+import java.util.function.Function;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JMenuBar;

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/GraphZoomScrollPaneDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/GraphZoomScrollPaneDemo.java
@@ -8,8 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
@@ -33,10 +31,10 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
-import java.awt.Paint;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
+import java.util.function.Function;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JFrame;
@@ -126,9 +124,9 @@ public class GraphZoomScrollPaneDemo {
         .setVertexRenderer(
             new GradientVertexRenderer<Integer>(
                 vv, Color.white, Color.red, Color.white, Color.blue, false));
-    vv.getRenderContext().setEdgeDrawPaintTransformer(Functions.<Paint>constant(Color.lightGray));
-    vv.getRenderContext().setArrowFillPaintTransformer(Functions.<Paint>constant(Color.lightGray));
-    vv.getRenderContext().setArrowDrawPaintTransformer(Functions.<Paint>constant(Color.lightGray));
+    vv.getRenderContext().setEdgeDrawPaintTransformer(e -> Color.lightGray);
+    vv.getRenderContext().setArrowFillPaintTransformer(a -> Color.lightGray);
+    vv.getRenderContext().setArrowDrawPaintTransformer(a -> Color.lightGray);
 
     // add my listeners for ToolTips
     vv.setVertexToolTipTransformer(new ToStringLabeller());

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/ImageEdgeLabelDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/ImageEdgeLabelDemo.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
@@ -31,6 +30,7 @@ import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.net.URL;
+import java.util.function.Function;
 import javax.swing.BorderFactory;
 import javax.swing.JApplet;
 import javax.swing.JButton;

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/L2RTreeLayoutDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/L2RTreeLayoutDemo.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Functions;
 import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.algorithms.layout.PolarPoint;
 import edu.uci.ics.jung.algorithms.layout.RadialTreeLayout;
@@ -36,7 +35,6 @@ import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GridLayout;
-import java.awt.Paint;
 import java.awt.Shape;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -92,7 +90,7 @@ public class L2RTreeLayoutDemo extends JApplet {
     vv.getRenderContext().setVertexLabelTransformer(new ToStringLabeller());
     // add a listener for ToolTips
     vv.setVertexToolTipTransformer(new ToStringLabeller());
-    vv.getRenderContext().setArrowFillPaintTransformer(Functions.<Paint>constant(Color.lightGray));
+    vv.getRenderContext().setArrowFillPaintTransformer(a -> Color.lightGray);
     rings = new Rings();
 
     setLtoR(vv);

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/LensDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/LensDemo.java
@@ -8,8 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
@@ -58,6 +56,7 @@ import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.ButtonGroup;
@@ -118,7 +117,7 @@ public class LensDemo extends JApplet {
 
     Dimension preferredSize = new Dimension(600, 600);
     Map<String, Point2D> map = new HashMap<String, Point2D>();
-    Function<String, Point2D> vlf = Functions.forMap(map);
+    Function<String, Point2D> vlf = map::get;
     grid = this.generateVertexGrid(map, preferredSize, 25);
     gridLayout = new StaticLayout<String>(grid.asGraph(), vlf, preferredSize);
 
@@ -139,8 +138,7 @@ public class LensDemo extends JApplet {
     vv.getRenderContext().setVertexLabelTransformer(new ToStringLabeller());
 
     final Function<? super String, Shape> ovals = vv.getRenderContext().getVertexShapeTransformer();
-    final Function<? super String, Shape> squares =
-        Functions.<Shape>constant(new Rectangle2D.Float(-10, -10, 20, 20));
+    final Function<? super String, Shape> squares = n -> new Rectangle2D.Float(-10, -10, 20, 20);
 
     // add a listener for ToolTips
     vv.setVertexToolTipTransformer(new ToStringLabeller());
@@ -294,7 +292,7 @@ public class LensDemo extends JApplet {
             if (e.getStateChange() == ItemEvent.SELECTED) {
               visualizationModel.setGraphLayout(gridLayout);
               vv.getRenderContext().setVertexShapeTransformer(squares);
-              vv.getRenderContext().setVertexLabelTransformer(Functions.<String>constant(null));
+              vv.getRenderContext().setVertexLabelTransformer(n -> null);
               vv.repaint();
             }
           }

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/LensVertexImageShaperDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/LensVertexImageShaperDemo.java
@@ -8,8 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
@@ -48,6 +46,7 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 import javax.swing.BorderFactory;
 import javax.swing.ButtonGroup;
 import javax.swing.Icon;
@@ -154,7 +153,7 @@ public class LensVertexImageShaperDemo extends JApplet {
     final VertexIconShapeTransformer<Number> vertexImageShapeFunction =
         new VertexIconShapeTransformer<Number>(new EllipseVertexShapeTransformer<Number>());
 
-    final Function<Number, Icon> vertexIconFunction = Functions.forMap(iconMap);
+    final Function<Number, Icon> vertexIconFunction = iconMap::get;
 
     vertexImageShapeFunction.setIconMap(iconMap);
 

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/MultiViewDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/MultiViewDemo.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Functions;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.layout.FRLayout;
 import edu.uci.ics.jung.algorithms.layout.NetworkElementAccessor;
@@ -41,7 +40,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.GridLayout;
-import java.awt.Shape;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
@@ -117,9 +115,7 @@ public class MultiViewDemo extends JApplet {
     vv3 = new VisualizationViewer<String, Number>(visualizationModel, preferredSize);
 
     vv1.getRenderContext().setEdgeShapeTransformer(EdgeShape.line(graph));
-    vv2.getRenderContext()
-        .setVertexShapeTransformer(
-            Functions.<Shape>constant(new Rectangle2D.Float(-6, -6, 12, 12)));
+    vv2.getRenderContext().setVertexShapeTransformer(n -> new Rectangle2D.Float(-6, -6, 12, 12));
 
     vv2.getRenderContext().setEdgeShapeTransformer(EdgeShape.quadCurve(graph));
 

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/PluggableRendererDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/PluggableRendererDemo.java
@@ -10,8 +10,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.graph.MutableNetwork;
@@ -67,6 +65,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import javax.swing.AbstractAction;
 import javax.swing.AbstractButton;
 import javax.swing.BorderFactory;
@@ -256,8 +255,8 @@ public class PluggableRendererDemo extends JApplet implements ActionListener {
     vsh = new VertexStrokeHighlight<Integer, Number>(graph, picked_state);
     vff = new VertexFontTransformer<Integer>();
     eff = new EdgeFontTransformer<Number>();
-    vs_none = Functions.constant(null);
-    es_none = Functions.constant(null);
+    vs_none = n -> null;
+    es_none = e -> null;
     vssa = new VertexShapeSizeAspect<Integer, Number>(graph, voltages);
     show_vertex = new VertexDisplayPredicate<Integer>(graph, false);
     show_edge = new EdgeDisplayPredicate<Number>(edge_weight, false);
@@ -289,8 +288,8 @@ public class PluggableRendererDemo extends JApplet implements ActionListener {
     vv.getRenderContext().setEdgeIncludePredicate(show_edge);
     vv.getRenderContext().setEdgeShapeTransformer(EdgeShape.line(graph));
 
-    vv.getRenderContext().setArrowFillPaintTransformer(Functions.<Paint>constant(Color.lightGray));
-    vv.getRenderContext().setArrowDrawPaintTransformer(Functions.<Paint>constant(Color.black));
+    vv.getRenderContext().setArrowFillPaintTransformer(n -> Color.lightGray);
+    vv.getRenderContext().setArrowDrawPaintTransformer(n -> Color.black);
     JPanel jp = new JPanel();
     jp.setLayout(new BorderLayout());
 
@@ -345,7 +344,7 @@ public class PluggableRendererDemo extends JApplet implements ActionListener {
     for (Number e : g.edges()) {
       edge_weight.put(e, Math.random());
     }
-    es = new NumberFormattingTransformer<Number>(Functions.forMap(edge_weight));
+    es = new NumberFormattingTransformer<Number>(edge_weight::get);
 
     // collect the seeds used to define the random graph
     seedVertices = generator.seedNodes();
@@ -367,7 +366,7 @@ public class PluggableRendererDemo extends JApplet implements ActionListener {
       source = !source;
     }
     VoltageScorer<Integer, Number> voltage_scores =
-        new VoltageScorer<Integer, Number>(g, Functions.forMap(edge_weight), sources, sinks);
+        new VoltageScorer<Integer, Number>(g, edge_weight::get, sources, sinks);
     voltage_scores.evaluate();
     voltages = new VertexScoreTransformer<Integer, Double>(voltage_scores);
     vs = new NumberFormattingTransformer<Integer>(voltages);
@@ -677,11 +676,8 @@ public class PluggableRendererDemo extends JApplet implements ActionListener {
         gradient_level = GRADIENT_RELATIVE;
       }
     } else if (source == fill_edges) {
-      if (source.isSelected()) {
-        vv.getRenderContext().setEdgeFillPaintTransformer(edgeFillPaint);
-      } else {
-        vv.getRenderContext().setEdgeFillPaintTransformer(Functions.<Paint>constant(null));
-      }
+      vv.getRenderContext()
+          .setEdgeFillPaintTransformer(source.isSelected() ? edgeFillPaint : edge -> null);
     }
     vv.repaint();
   }

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/ShortestPathDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/ShortestPathDemo.java
@@ -3,7 +3,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.graph.ElementOrder;
 import com.google.common.graph.EndpointPair;
@@ -32,6 +31,7 @@ import java.awt.event.ActionListener;
 import java.awt.geom.Point2D;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JComboBox;

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/TreeCollapseDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/TreeCollapseDemo.java
@@ -8,8 +8,6 @@ package edu.uci.ics.jung.samples;
  *
  */
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.algorithms.layout.PolarPoint;
@@ -37,7 +35,6 @@ import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GridLayout;
-import java.awt.Paint;
 import java.awt.Shape;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -49,6 +46,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import javax.swing.BorderFactory;
 import javax.swing.JApplet;
 import javax.swing.JButton;
@@ -100,7 +98,7 @@ public class TreeCollapseDemo extends JApplet {
     vv.getRenderContext().setVertexShapeTransformer(new ClusterVertexShapeFunction<String>());
     // add a listener for ToolTips
     vv.setVertexToolTipTransformer(new ToStringLabeller());
-    vv.getRenderContext().setArrowFillPaintTransformer(Functions.<Paint>constant(Color.lightGray));
+    vv.getRenderContext().setArrowFillPaintTransformer(n -> Color.lightGray);
     rings = new Rings();
 
     Container content = getContentPane();

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/TreeLayoutDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/TreeLayoutDemo.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Functions;
 import edu.uci.ics.jung.algorithms.layout.PolarPoint;
 import edu.uci.ics.jung.algorithms.layout.RadialTreeLayout;
 import edu.uci.ics.jung.algorithms.layout.TreeLayout;
@@ -35,7 +34,6 @@ import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GridLayout;
-import java.awt.Paint;
 import java.awt.Shape;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -90,7 +88,7 @@ public class TreeLayoutDemo extends JApplet {
     vv.getRenderContext().setVertexLabelTransformer(new ToStringLabeller());
     // add a listener for ToolTips
     vv.setVertexToolTipTransformer(new ToStringLabeller());
-    vv.getRenderContext().setArrowFillPaintTransformer(Functions.<Paint>constant(Color.lightGray));
+    vv.getRenderContext().setArrowFillPaintTransformer(n -> Color.lightGray);
     rings = new Rings();
 
     Container content = getContentPane();

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/UnicodeLabelDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/UnicodeLabelDemo.java
@@ -8,8 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
@@ -35,6 +33,7 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -69,7 +68,7 @@ public class UnicodeLabelDemo {
     vv.getRenderContext().setEdgeLabelRenderer(new DefaultEdgeLabelRenderer(Color.cyan));
     VertexIconShapeTransformer<Integer> vertexIconShapeFunction =
         new VertexIconShapeTransformer<Integer>(new EllipseVertexShapeTransformer<Integer>());
-    Function<Integer, Icon> vertexIconFunction = Functions.forMap(iconMap);
+    Function<Integer, Icon> vertexIconFunction = iconMap::get;
     vv.getRenderContext().setVertexShapeTransformer(vertexIconShapeFunction);
     vv.getRenderContext().setVertexIconTransformer(vertexIconFunction);
     loadImages(iconMap);

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexCollapseDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexCollapseDemo.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
 import com.google.common.base.Predicates;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.layout.FRLayout;
@@ -39,6 +38,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.function.Function;
 import javax.swing.BorderFactory;
 import javax.swing.JApplet;
 import javax.swing.JButton;

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexCollapseDemoWithLayouts.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexCollapseDemoWithLayouts.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Sets;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.layout.CircleLayout;
@@ -46,6 +45,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.function.Function;
 import javax.swing.BorderFactory;
 import javax.swing.JApplet;
 import javax.swing.JButton;

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexImageShaperDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexImageShaperDemo.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
@@ -55,6 +54,7 @@ import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexLabelAsShapeDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexLabelAsShapeDemo.java
@@ -8,8 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.layout.FRLayout;
 import edu.uci.ics.jung.algorithms.layout.Layout;
@@ -32,8 +30,6 @@ import java.awt.Color;
 import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.GridLayout;
-import java.awt.Paint;
-import java.awt.Stroke;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import javax.swing.BorderFactory;
@@ -80,20 +76,11 @@ public class VertexLabelAsShapeDemo extends JApplet {
     // customize the render context
     vv.getRenderContext()
         .setVertexLabelTransformer(
-            // this chains together Functions so that the html tags
-            // are prepended to the toString method output
-            Functions.<Object, String, String>compose(
-                new Function<String, String>() {
-                  public String apply(String input) {
-                    return "<html><center>Vertex<p>" + input;
-                  }
-                },
-                new ToStringLabeller()));
+            new ToStringLabeller().andThen(input -> "<html><center>Vertex<p>" + input));
     vv.getRenderContext().setVertexShapeTransformer(vlasr);
     vv.getRenderContext().setVertexLabelRenderer(new DefaultVertexLabelRenderer(Color.red));
-    vv.getRenderContext().setEdgeDrawPaintTransformer(Functions.<Paint>constant(Color.yellow));
-    vv.getRenderContext()
-        .setEdgeStrokeTransformer(Functions.<Stroke>constant(new BasicStroke(2.5f)));
+    vv.getRenderContext().setEdgeDrawPaintTransformer(e -> Color.yellow);
+    vv.getRenderContext().setEdgeStrokeTransformer(e -> new BasicStroke(2.5f));
 
     // customize the renderer
     vv.getRenderer()

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/VisualizationImageServerDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/VisualizationImageServerDemo.java
@@ -8,7 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Functions;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
@@ -22,7 +21,6 @@ import java.awt.Color;
 import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Image;
-import java.awt.Paint;
 import java.awt.geom.Point2D;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -56,9 +54,9 @@ public class VisualizationImageServerDemo {
         .setVertexRenderer(
             new GradientVertexRenderer<Integer>(
                 vv, Color.white, Color.red, Color.white, Color.blue, false));
-    vv.getRenderContext().setEdgeDrawPaintTransformer(Functions.<Paint>constant(Color.lightGray));
-    vv.getRenderContext().setArrowFillPaintTransformer(Functions.<Paint>constant(Color.lightGray));
-    vv.getRenderContext().setArrowDrawPaintTransformer(Functions.<Paint>constant(Color.lightGray));
+    vv.getRenderContext().setEdgeDrawPaintTransformer(e -> Color.lightGray);
+    vv.getRenderContext().setArrowFillPaintTransformer(e -> Color.lightGray);
+    vv.getRenderContext().setArrowDrawPaintTransformer(e -> Color.lightGray);
 
     vv.getRenderContext().setVertexLabelTransformer(new ToStringLabeller());
     vv.getRenderer().getVertexLabelRenderer().setPositioner(new InsidePositioner());

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/WorldMapGraphDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/WorldMapGraphDemo.java
@@ -8,8 +8,6 @@
  */
 package edu.uci.ics.jung.samples;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
@@ -40,6 +38,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import javax.swing.ImageIcon;
 import javax.swing.JApplet;
 import javax.swing.JButton;
@@ -88,8 +87,8 @@ public class WorldMapGraphDemo extends JApplet {
     Layout<String> layout =
         new StaticLayout<String>(
             graph.asGraph(),
-            Functions.<String, String[], Point2D>compose(
-                new LatLonPixelTransformer(new Dimension(2000, 1000)), new CityTransformer(map)));
+            new CityTransformer(map)
+                .andThen(new LatLonPixelTransformer(new Dimension(2000, 1000))));
 
     layout.setSize(layoutSize);
     vv = new VisualizationViewer<String, Number>(graph, layout, new Dimension(800, 400));

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/PluggableRenderContext.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/PluggableRenderContext.java
@@ -7,8 +7,6 @@
  */
 package edu.uci.ics.jung.visualization;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.graph.Network;
@@ -31,6 +29,7 @@ import java.awt.Paint;
 import java.awt.Shape;
 import java.awt.Stroke;
 import java.awt.geom.Ellipse2D;
+import java.util.function.Function;
 import javax.swing.CellRendererPane;
 import javax.swing.Icon;
 import javax.swing.JComponent;
@@ -41,27 +40,22 @@ public class PluggableRenderContext<V, E> implements RenderContext<V, E> {
 
   protected float arrowPlacementTolerance = 1;
   protected Predicate<V> vertexIncludePredicate = Predicates.alwaysTrue();
-  protected Function<? super V, Stroke> vertexStrokeTransformer =
-      Functions.<Stroke>constant(new BasicStroke(1.0f));
+  protected Function<? super V, Stroke> vertexStrokeTransformer = n -> new BasicStroke(1.0f);
 
   protected Function<? super V, Shape> vertexShapeTransformer =
-      Functions.<Shape>constant(new Ellipse2D.Float(-10, -10, 20, 20));
+      n -> new Ellipse2D.Float(-10, -10, 20, 20);
 
-  protected Function<? super V, String> vertexLabelTransformer = Functions.constant(null);
+  protected Function<? super V, String> vertexLabelTransformer = n -> null;
   protected Function<V, Icon> vertexIconTransformer;
   protected Function<? super V, Font> vertexFontTransformer =
-      Functions.constant(new Font("Helvetica", Font.PLAIN, 12));
+      n -> new Font("Helvetica", Font.PLAIN, 12);
 
-  protected Function<? super V, Paint> vertexDrawPaintTransformer =
-      Functions.<Paint>constant(Color.BLACK);
-  protected Function<? super V, Paint> vertexFillPaintTransformer =
-      Functions.<Paint>constant(Color.RED);
+  protected Function<? super V, Paint> vertexDrawPaintTransformer = n -> Color.BLACK;
+  protected Function<? super V, Paint> vertexFillPaintTransformer = n -> Color.RED;
 
-  protected Function<? super E, String> edgeLabelTransformer = Functions.constant(null);
-  protected Function<? super E, Stroke> edgeStrokeTransformer =
-      Functions.<Stroke>constant(new BasicStroke(1.0f));
-  protected Function<? super E, Stroke> edgeArrowStrokeTransformer =
-      Functions.<Stroke>constant(new BasicStroke(1.0f));
+  protected Function<? super E, String> edgeLabelTransformer = e -> null;
+  protected Function<? super E, Stroke> edgeStrokeTransformer = e -> new BasicStroke(1.0f);
+  protected Function<? super E, Stroke> edgeArrowStrokeTransformer = e -> new BasicStroke(1.0f);
 
   private static final int EDGE_ARROW_LENGTH = 10;
   private static final int EDGE_ARROW_WIDTH = 8;
@@ -71,20 +65,17 @@ public class PluggableRenderContext<V, E> implements RenderContext<V, E> {
 
   protected Predicate<E> edgeIncludePredicate = Predicates.alwaysTrue();
   protected Function<? super E, Font> edgeFontTransformer =
-      Functions.constant(new Font("Helvetica", Font.PLAIN, 12));
+      n -> new Font("Helvetica", Font.PLAIN, 12);
 
   private static final float DIRECTED_EDGE_LABEL_CLOSENESS = 0.65f;
   private static final float UNDIRECTED_EDGE_LABEL_CLOSENESS = 0.65f;
   protected float edgeLabelCloseness;
 
   protected Function<? super E, Shape> edgeShapeTransformer;
-  protected Function<? super E, Paint> edgeFillPaintTransformer = Functions.constant(null);
-  protected Function<? super E, Paint> edgeDrawPaintTransformer =
-      Functions.<Paint>constant(Color.black);
-  protected Function<? super E, Paint> arrowFillPaintTransformer =
-      Functions.<Paint>constant(Color.black);
-  protected Function<? super E, Paint> arrowDrawPaintTransformer =
-      Functions.<Paint>constant(Color.black);
+  protected Function<? super E, Paint> edgeFillPaintTransformer = n -> null;
+  protected Function<? super E, Paint> edgeDrawPaintTransformer = n -> Color.black;
+  protected Function<? super E, Paint> arrowFillPaintTransformer = n -> Color.black;
+  protected Function<? super E, Paint> arrowDrawPaintTransformer = n -> Color.black;
 
   protected EdgeIndexFunction<E> parallelEdgeIndexFunction;
 

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/RenderContext.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/RenderContext.java
@@ -1,6 +1,5 @@
 package edu.uci.ics.jung.visualization;
 
-import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.layout.NetworkElementAccessor;
@@ -14,6 +13,7 @@ import java.awt.Font;
 import java.awt.Paint;
 import java.awt.Shape;
 import java.awt.Stroke;
+import java.util.function.Function;
 import javax.swing.CellRendererPane;
 import javax.swing.Icon;
 import javax.swing.JComponent;

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/VisualizationViewer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/VisualizationViewer.java
@@ -9,7 +9,6 @@
  */
 package edu.uci.ics.jung.visualization;
 
-import com.google.common.base.Function;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.visualization.control.GraphMouseListener;
@@ -22,6 +21,7 @@ import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.awt.event.MouseWheelListener;
 import java.awt.geom.Point2D;
+import java.util.function.Function;
 import javax.swing.ToolTipManager;
 
 /**

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/control/LabelEditingGraphMousePlugin.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/control/LabelEditingGraphMousePlugin.java
@@ -11,7 +11,6 @@
  */
 package edu.uci.ics.jung.visualization.control;
 
-import com.google.common.base.Function;
 import edu.uci.ics.jung.algorithms.layout.NetworkElementAccessor;
 import edu.uci.ics.jung.algorithms.util.MapSettableTransformer;
 import edu.uci.ics.jung.visualization.Layer;
@@ -21,6 +20,7 @@ import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.geom.Point2D;
+import java.util.function.Function;
 import javax.swing.JOptionPane;
 
 /** @author Tom Nelson */

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/AbstractVertexShapeTransformer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/AbstractVertexShapeTransformer.java
@@ -11,9 +11,8 @@
  */
 package edu.uci.ics.jung.visualization.decorators;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import edu.uci.ics.jung.visualization.util.VertexShapeFactory;
+import java.util.function.Function;
 
 /** @author Joshua O'Madadhain */
 public abstract class AbstractVertexShapeTransformer<V>
@@ -32,7 +31,7 @@ public abstract class AbstractVertexShapeTransformer<V>
   }
 
   public AbstractVertexShapeTransformer() {
-    this(Functions.constant(DEFAULT_SIZE), Functions.constant(DEFAULT_ASPECT_RATIO));
+    this(n -> DEFAULT_SIZE, n -> DEFAULT_ASPECT_RATIO);
   }
 
   public void setSizeTransformer(Function<V, Integer> vsf) {

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/EdgeShape.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/EdgeShape.java
@@ -12,7 +12,6 @@ package edu.uci.ics.jung.visualization.decorators;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Function;
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.graph.util.EdgeIndexFunction;
@@ -26,6 +25,7 @@ import java.awt.geom.Line2D;
 import java.awt.geom.QuadCurve2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.geom.RectangularShape;
+import java.util.function.Function;
 
 /**
  * An interface for decorators that return a <code>Shape</code> for a specified edge.

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/EllipseVertexShapeTransformer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/EllipseVertexShapeTransformer.java
@@ -11,8 +11,8 @@
  */
 package edu.uci.ics.jung.visualization.decorators;
 
-import com.google.common.base.Function;
 import java.awt.Shape;
+import java.util.function.Function;
 
 /** @author Joshua O'Madadhain */
 public class EllipseVertexShapeTransformer<V> extends AbstractVertexShapeTransformer<V>

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/GradientEdgePaintTransformer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/GradientEdgePaintTransformer.java
@@ -13,7 +13,6 @@ package edu.uci.ics.jung.visualization.decorators;
 
 import static edu.uci.ics.jung.graph.util.Graphs.isSelfLoop;
 
-import com.google.common.base.Function;
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.layout.Layout;
@@ -24,6 +23,7 @@ import java.awt.Color;
 import java.awt.GradientPaint;
 import java.awt.Paint;
 import java.awt.geom.Point2D;
+import java.util.function.Function;
 
 /**
  * Creates <code>GradientPaint</code> instances which can be used to paint an <code>Edge</code>. For

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/InterpolatingVertexSizeTransformer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/InterpolatingVertexSizeTransformer.java
@@ -11,7 +11,7 @@
  */
 package edu.uci.ics.jung.visualization.decorators;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 /**
  * Provides vertex sizes that are spaced proportionally between min_size and max_size depending on

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/NumberFormattingTransformer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/NumberFormattingTransformer.java
@@ -11,8 +11,8 @@
  */
 package edu.uci.ics.jung.visualization.decorators;
 
-import com.google.common.base.Function;
 import java.text.NumberFormat;
+import java.util.function.Function;
 
 /**
  * Transforms inputs to String representations by chaining an input {@code Number}-generating {@code

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/ParallelEdgeShapeTransformer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/ParallelEdgeShapeTransformer.java
@@ -9,9 +9,9 @@
  */
 package edu.uci.ics.jung.visualization.decorators;
 
-import com.google.common.base.Function;
 import edu.uci.ics.jung.graph.util.EdgeIndexFunction;
 import java.awt.Shape;
+import java.util.function.Function;
 
 /**
  * An abstract class for edge-to-Shape functions that work with parallel edges.

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/PickableEdgePaintTransformer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/PickableEdgePaintTransformer.java
@@ -11,9 +11,9 @@
  */
 package edu.uci.ics.jung.visualization.decorators;
 
-import com.google.common.base.Function;
 import edu.uci.ics.jung.visualization.picking.PickedInfo;
 import java.awt.Paint;
+import java.util.function.Function;
 
 /**
  * Paints each edge according to the <code>Paint</code> parameters given in the constructor, so that

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/PickableVertexIconTransformer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/PickableVertexIconTransformer.java
@@ -11,8 +11,8 @@
  */
 package edu.uci.ics.jung.visualization.decorators;
 
-import com.google.common.base.Function;
 import edu.uci.ics.jung.visualization.picking.PickedInfo;
+import java.util.function.Function;
 import javax.swing.Icon;
 
 /**

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/PickableVertexPaintTransformer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/PickableVertexPaintTransformer.java
@@ -11,9 +11,9 @@
  */
 package edu.uci.ics.jung.visualization.decorators;
 
-import com.google.common.base.Function;
 import edu.uci.ics.jung.visualization.picking.PickedInfo;
 import java.awt.Paint;
+import java.util.function.Function;
 
 /**
  * Paints each vertex according to the <code>Paint</code> parameters given in the constructor, so

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/SettableVertexShapeTransformer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/SettableVertexShapeTransformer.java
@@ -11,8 +11,8 @@
  */
 package edu.uci.ics.jung.visualization.decorators;
 
-import com.google.common.base.Function;
 import java.awt.Shape;
+import java.util.function.Function;
 
 /** @author Joshua O'Madadhain */
 public interface SettableVertexShapeTransformer<V> extends Function<V, Shape> {

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/ToStringLabeller.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/ToStringLabeller.java
@@ -12,7 +12,7 @@
  */
 package edu.uci.ics.jung.visualization.decorators;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 /**
  * Labels vertices by their toString. This class functions as a drop-in replacement for the default

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/VertexIconShapeTransformer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/VertexIconShapeTransformer.java
@@ -10,13 +10,13 @@
 
 package edu.uci.ics.jung.visualization.decorators;
 
-import com.google.common.base.Function;
 import edu.uci.ics.jung.visualization.util.ImageShapeUtils;
 import java.awt.Image;
 import java.awt.Shape;
 import java.awt.geom.AffineTransform;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/CachingLayout.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/CachingLayout.java
@@ -10,8 +10,6 @@
 
 package edu.uci.ics.jung.visualization.layout;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -20,6 +18,7 @@ import edu.uci.ics.jung.algorithms.layout.LayoutDecorator;
 import edu.uci.ics.jung.visualization.util.Caching;
 import java.awt.geom.Point2D;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * A LayoutDecorator that caches locations in a clearable Map. This can be used to ensure that edge
@@ -35,26 +34,12 @@ public class CachingLayout<V> extends LayoutDecorator<V> implements Caching {
 
   public CachingLayout(Layout<V> delegate) {
     super(delegate);
-    Function<V, Point2D> chain =
-        Functions.<V, Point2D, Point2D>compose(
-            new Function<Point2D, Point2D>() {
-              public Point2D apply(Point2D p) {
-                return (Point2D) p.clone();
-              }
-            },
-            delegate);
-    this.locations = CacheBuilder.newBuilder().build(CacheLoader.from(chain));
+    Function<V, Point2D> chain = delegate.andThen(p -> (Point2D) p.clone());
+    this.locations = CacheBuilder.newBuilder().build(CacheLoader.from(chain::apply));
   }
 
   public void clear() {
-    this.locations =
-        CacheBuilder.newBuilder()
-            .build(
-                new CacheLoader<V, Point2D>() {
-                  public Point2D load(V vertex) {
-                    return new Point2D.Double();
-                  }
-                });
+    this.locations = CacheBuilder.newBuilder().build(CacheLoader.from(() -> new Point2D.Double()));
   }
 
   public void init() {}

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/ObservableCachingLayout.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/ObservableCachingLayout.java
@@ -10,8 +10,6 @@
 
 package edu.uci.ics.jung.visualization.layout;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -26,6 +24,7 @@ import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import javax.swing.event.ChangeListener;
 
 /**
@@ -49,9 +48,8 @@ public class ObservableCachingLayout<V> extends LayoutDecorator<V>
   public ObservableCachingLayout(Graph<V> graph, Layout<V> delegate) {
     super(delegate);
     this.graph = graph;
-    Function<V, Point2D> chain =
-        Functions.<V, Point2D, Point2D>compose(p -> (Point2D) p.clone(), delegate);
-    this.locations = CacheBuilder.newBuilder().build(CacheLoader.from(chain));
+    Function<V, Point2D> chain = delegate.andThen(p -> (Point2D) p.clone());
+    this.locations = CacheBuilder.newBuilder().build(CacheLoader.from(chain::apply));
   }
 
   @Override

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/VertexLabelAsShapeRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/VertexLabelAsShapeRenderer.java
@@ -9,7 +9,6 @@
  */
 package edu.uci.ics.jung.visualization.renderers;
 
-import com.google.common.base.Function;
 import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.visualization.Layer;
 import edu.uci.ics.jung.visualization.RenderContext;
@@ -21,6 +20,7 @@ import java.awt.Shape;
 import java.awt.geom.Point2D;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Renders Vertex Labels, but can also supply Shapes for vertices. This has the effect of making the

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/util/LabelWrapper.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/util/LabelWrapper.java
@@ -8,7 +8,7 @@
  */
 package edu.uci.ics.jung.visualization.util;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 /**
  * A utility to wrap long lines, creating html strings with line breaks at a settable max line

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/util/VertexShapeFactory.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/util/VertexShapeFactory.java
@@ -9,8 +9,6 @@
  */
 package edu.uci.ics.jung.visualization.util;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import java.awt.Shape;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
@@ -18,6 +16,7 @@ import java.awt.geom.GeneralPath;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.geom.RoundRectangle2D;
+import java.util.function.Function;
 
 /**
  * A utility class for generating <code>Shape</code>s for drawing vertices. The available shapes
@@ -50,7 +49,7 @@ public class VertexShapeFactory<V> {
    * ratio of 1.
    */
   public VertexShapeFactory() {
-    this(Functions.constant(10), Functions.constant(1.0f));
+    this(n -> 10, n -> 1.0f);
   }
 
   private static final Rectangle2D theRectangle = new Rectangle2D.Float();


### PR DESCRIPTION
Also, replacing old uses of Functions.constant() with lambdas, and using method references where Guava Functions are still expected (e.g. LoadingCache) or where Functions.forMap() had been used.