### PR TITLE
Layout mediator

### DIFF
--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/AddNodeDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/AddNodeDemo.java
@@ -129,7 +129,8 @@ public class AddNodeDemo extends javax.swing.JApplet {
               layout.setSize(d);
               vv.getModel().setGraphLayout(layout, d);
               Layout<Number> delegateLayout =
-                  ((LayoutDecorator<Number>) vv.getModel().getGraphLayout()).getDelegate();
+                  ((LayoutDecorator<Number>) vv.getModel().getLayoutMediator().getLayout())
+                      .getDelegate();
               System.err.println("layout: " + delegateLayout.getClass().getName());
               //                    vv.repaint();
             } else {
@@ -137,7 +138,8 @@ public class AddNodeDemo extends javax.swing.JApplet {
               layout = new FRLayout<Number>(g.asGraph(), d);
               vv.getModel().setGraphLayout(layout, d);
               Layout<Number> delegateLayout =
-                  ((LayoutDecorator<Number>) vv.getModel().getGraphLayout()).getDelegate();
+                  ((LayoutDecorator<Number>) vv.getModel().getLayoutMediator().getLayout())
+                      .getDelegate();
               System.err.println("layout: " + delegateLayout.getClass().getName());
               //                    vv.repaint();
             }

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/ClusteringDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/ClusteringDemo.java
@@ -299,7 +299,7 @@ public class ClusteringDemo extends JApplet {
   }
 
   private void groupCluster(AggregateLayout<Number> layout, Set<Number> vertices) {
-    if (vertices.size() < vv.getModel().getNetwork().nodes().size()) {
+    if (vertices.size() < vv.getModel().getLayoutMediator().getLayout().nodes().size()) {
       Point2D center = layout.apply(vertices.iterator().next());
       MutableNetwork<Number, Number> subGraph = NetworkBuilder.undirected().build();
       for (Number v : vertices) {

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/GraphFromGraphMLDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/GraphFromGraphMLDemo.java
@@ -92,7 +92,7 @@ public class GraphFromGraphMLDemo {
     vv.addGraphMouseListener(new TestGraphMouseListener<Number>());
     vv.getRenderer()
         .setVertexRenderer(
-            new GradientVertexRenderer<Number>(
+            new GradientVertexRenderer<Number, Number>(
                 vv, Color.white, Color.red, Color.white, Color.blue, false));
 
     // add my listeners for ToolTips

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/GraphZoomScrollPaneDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/GraphZoomScrollPaneDemo.java
@@ -122,7 +122,7 @@ public class GraphZoomScrollPaneDemo {
     vv.addGraphMouseListener(new TestGraphMouseListener<Integer>());
     vv.getRenderer()
         .setVertexRenderer(
-            new GradientVertexRenderer<Integer>(
+            new GradientVertexRenderer<Integer, Number>(
                 vv, Color.white, Color.red, Color.white, Color.blue, false));
     vv.getRenderContext().setEdgeDrawPaintTransformer(e -> Color.lightGray);
     vv.getRenderContext().setArrowFillPaintTransformer(a -> Color.lightGray);

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/L2RTreeLayoutDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/L2RTreeLayoutDemo.java
@@ -166,7 +166,7 @@ public class L2RTreeLayoutDemo extends JApplet {
   }
 
   private void setLtoR(VisualizationViewer<String, Integer> vv) {
-    Layout<String> layout = vv.getModel().getGraphLayout();
+    Layout<String> layout = vv.getModel().getLayoutMediator().getLayout();
     Dimension d = layout.getSize();
     Point2D center = new Point2D.Double(d.width / 2, d.height / 2);
     vv.getRenderContext()

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/SatelliteViewDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/SatelliteViewDemo.java
@@ -136,7 +136,8 @@ public class SatelliteViewDemo<V, E> extends JApplet {
             new PickableVertexPaintTransformer<String>(
                 vv2.getPickedVertexState(), Color.red, Color.yellow));
     vv1.getRenderer()
-        .setVertexRenderer(new GradientVertexRenderer<String>(vv1, Color.red, Color.white, true));
+        .setVertexRenderer(
+            new GradientVertexRenderer<String, Number>(vv1, Color.red, Color.white, true));
     vv1.getRenderContext().setVertexLabelTransformer(new ToStringLabeller());
     vv1.getRenderer().getVertexLabelRenderer().setPosition(Renderer.VertexLabel.Position.CNTR);
 

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/ShortestPathDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/ShortestPathDemo.java
@@ -98,7 +98,7 @@ public class ShortestPathDemo extends JPanel {
                 p1 = vv.getRenderContext().getMultiLayerTransformer().transform(Layer.LAYOUT, p1);
                 p2 = vv.getRenderContext().getMultiLayerTransformer().transform(Layer.LAYOUT, p2);
                 Renderer<String, Number> renderer = vv.getRenderer();
-                renderer.renderEdge(e);
+                renderer.renderEdge(vv.getRenderContext(), vv.getModel().getLayoutMediator(), e);
               }
             }
           }

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/ShowLayouts.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/ShowLayouts.java
@@ -97,7 +97,8 @@ public class ShowLayouts extends JApplet {
       Layouts layoutType = (Layouts) jcb.getSelectedItem();
       try {
         // TODO: is this the right input network?  or should it be g_array[graph_index]?
-        Layout<Integer> layout = createLayout(layoutType, vv.getModel().getNetwork());
+        Layout<Integer> layout =
+            createLayout(layoutType, vv.getModel().getLayoutMediator().getNetwork());
         layout.setInitializer(vv.getGraphLayout());
         layout.setSize(vv.getSize());
         LayoutTransition<Integer, Number> lt =

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexCollapseDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexCollapseDemo.java
@@ -193,7 +193,7 @@ public class VertexCollapseDemo extends JApplet {
               Iterator pickedIter = picked.iterator();
               Object nodeU = pickedIter.next();
               Object nodeV = pickedIter.next();
-              Network graph = vv.getModel().getNetwork();
+              Network graph = vv.getModel().getLayoutMediator().getNetwork();
               Collection edges = new HashSet(graph.incidentEdges(nodeU));
               edges.retainAll(graph.incidentEdges(nodeV));
               exclusions.addAll(edges);
@@ -212,7 +212,7 @@ public class VertexCollapseDemo extends JApplet {
               Iterator pickedIter = picked.iterator();
               Object nodeU = pickedIter.next();
               Object nodeV = pickedIter.next();
-              Network graph = vv.getModel().getNetwork();
+              Network graph = vv.getModel().getLayoutMediator().getNetwork();
               Collection edges = new HashSet(graph.incidentEdges(nodeU));
               edges.retainAll(graph.incidentEdges(nodeV));
               exclusions.removeAll(edges);
@@ -229,7 +229,8 @@ public class VertexCollapseDemo extends JApplet {
             Collection picked = new HashSet(vv.getPickedVertexState().getPicked());
             for (Object v : picked) {
               if (v instanceof Network) {
-                Network g = collapser.expand(vv.getModel().getNetwork(), (Network) v);
+                Network g =
+                    collapser.expand(vv.getModel().getLayoutMediator().getNetwork(), (Network) v);
                 vv.getRenderContext().getParallelEdgeIndexFunction().reset();
                 // TODO: need to update VV with new layout
                 layout = new FRLayout(g.asGraph());
@@ -245,7 +246,7 @@ public class VertexCollapseDemo extends JApplet {
         new ActionListener() {
 
           public void actionPerformed(ActionEvent e) {
-            layout = new FRLayout(vv.getModel().getNetwork().asGraph());
+            layout = new FRLayout(vv.getModel().getLayoutMediator().getNetwork().asGraph());
             // TODO: need to update VV with new layout
             exclusions.clear();
             vv.repaint();

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexImageShaperDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexImageShaperDemo.java
@@ -12,7 +12,6 @@ import com.google.common.graph.MutableNetwork;
 import com.google.common.graph.Network;
 import com.google.common.graph.NetworkBuilder;
 import edu.uci.ics.jung.algorithms.layout.FRLayout;
-import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.algorithms.layout.util.RandomLocationTransformer;
 import edu.uci.ics.jung.visualization.GraphZoomScrollPane;
 import edu.uci.ics.jung.visualization.Layer;
@@ -34,6 +33,7 @@ import edu.uci.ics.jung.visualization.renderers.DefaultEdgeLabelRenderer;
 import edu.uci.ics.jung.visualization.renderers.DefaultVertexLabelRenderer;
 import edu.uci.ics.jung.visualization.transform.shape.GraphicsDecorator;
 import edu.uci.ics.jung.visualization.util.ImageShapeUtils;
+import edu.uci.ics.jung.visualization.util.LayoutMediator;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Container;
@@ -134,7 +134,7 @@ public class VertexImageShaperDemo extends JApplet {
     // This demo uses a special renderer to turn outlines on and off.
     // you do not need to do this in a real application.
     // Instead, just let vv use the Renderer it already has
-    vv.getRenderer().setVertexRenderer(new DemoRenderer<Number>(layout, vv.getRenderContext()));
+    vv.getRenderer().setVertexRenderer(new DemoRenderer<Number, Number>());
 
     Function<Number, Paint> vpf =
         new PickableVertexPaintTransformer<Number>(
@@ -480,15 +480,16 @@ public class VertexImageShaperDemo extends JApplet {
    *
    * @author Tom Nelson
    */
-  class DemoRenderer<V> extends BasicVertexRenderer<V> {
+  class DemoRenderer<V, E> extends BasicVertexRenderer<V, E> {
 
-    public DemoRenderer(Layout<V> layout, RenderContext<V, ?> rc) {
-      super(layout, rc);
-    }
+    //    public DemoRenderer(Layout<V> layout, RenderContext<V, ?> rc) {
+    //      super(layout, rc);
+    //    }
 
-    public void paintIconForVertex(V v) {
+    public void paintIconForVertex(
+        RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v) {
 
-      Point2D p = layout.apply(v);
+      Point2D p = layoutMediator.getLayout().apply(v);
       p = renderContext.getMultiLayerTransformer().transform(Layer.LAYOUT, p);
       float x = (float) p.getX();
       float y = (float) p.getY();
@@ -506,7 +507,7 @@ public class VertexImageShaperDemo extends JApplet {
         Shape s =
             AffineTransform.getTranslateInstance(x, y)
                 .createTransformedShape(renderContext.getVertexShapeTransformer().apply(v));
-        paintShapeForVertex(v, s);
+        paintShapeForVertex(renderContext, layoutMediator, v, s);
       }
       if (icon != null) {
         int xLoc = (int) (x - icon.getIconWidth() / 2);

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexImageShaperDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexImageShaperDemo.java
@@ -482,10 +482,6 @@ public class VertexImageShaperDemo extends JApplet {
    */
   class DemoRenderer<V, E> extends BasicVertexRenderer<V, E> {
 
-    //    public DemoRenderer(Layout<V> layout, RenderContext<V, ?> rc) {
-    //      super(layout, rc);
-    //    }
-
     public void paintIconForVertex(
         RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v) {
 

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexLabelAsShapeDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/VertexLabelAsShapeDemo.java
@@ -70,8 +70,8 @@ public class VertexLabelAsShapeDemo extends JApplet {
     vv = new VisualizationViewer<String, Number>(visualizationModel, preferredSize);
 
     // this class will provide both label drawing and vertex shapes
-    VertexLabelAsShapeRenderer<String> vlasr =
-        new VertexLabelAsShapeRenderer<String>(layout, vv.getRenderContext());
+    VertexLabelAsShapeRenderer<String, Number> vlasr =
+        new VertexLabelAsShapeRenderer<String, Number>(layout, vv.getRenderContext());
 
     // customize the render context
     vv.getRenderContext()
@@ -84,7 +84,8 @@ public class VertexLabelAsShapeDemo extends JApplet {
 
     // customize the renderer
     vv.getRenderer()
-        .setVertexRenderer(new GradientVertexRenderer<String>(vv, Color.gray, Color.white, true));
+        .setVertexRenderer(
+            new GradientVertexRenderer<String, Number>(vv, Color.gray, Color.white, true));
     vv.getRenderer().setVertexLabelRenderer(vlasr);
 
     vv.setBackground(Color.black);

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/VisualizationImageServerDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/VisualizationImageServerDemo.java
@@ -52,7 +52,7 @@ public class VisualizationImageServerDemo {
 
     vv.getRenderer()
         .setVertexRenderer(
-            new GradientVertexRenderer<Integer>(
+            new GradientVertexRenderer<Integer, Double>(
                 vv, Color.white, Color.red, Color.white, Color.blue, false));
     vv.getRenderContext().setEdgeDrawPaintTransformer(e -> Color.lightGray);
     vv.getRenderContext().setArrowFillPaintTransformer(e -> Color.lightGray);

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/WorldMapGraphDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/WorldMapGraphDemo.java
@@ -126,7 +126,7 @@ public class WorldMapGraphDemo extends JApplet {
 
     vv.getRenderer()
         .setVertexRenderer(
-            new GradientVertexRenderer<String>(
+            new GradientVertexRenderer<String, Number>(
                 vv, Color.white, Color.red, Color.white, Color.blue, false));
 
     // add my listeners for ToolTips

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/BasicVisualizationServer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/BasicVisualizationServer.java
@@ -140,8 +140,8 @@ public class BasicVisualizationServer<V, E> extends JPanel
    */
   public BasicVisualizationServer(VisualizationModel<V, E> model, Dimension preferredSize) {
     this.model = model;
-    renderContext = new PluggableRenderContext<V, E>(model.getNetwork());
-    renderer = new BasicRenderer<V, E>(model.getGraphLayout(), renderContext);
+    renderContext = new PluggableRenderContext<V, E>(model.getLayoutMediator().getNetwork());
+    renderer = new BasicRenderer<V, E>();
     model.addChangeListener(this);
     setDoubleBuffered(false);
     this.addComponentListener(new VisualizationListener(this));
@@ -244,7 +244,7 @@ public class BasicVisualizationServer<V, E> extends JPanel
   }
 
   public Layout<V> getGraphLayout() {
-    return model.getGraphLayout();
+    return model.getLayoutMediator().getLayout();
   }
 
   @Override
@@ -255,7 +255,7 @@ public class BasicVisualizationServer<V, E> extends JPanel
       if (d.width <= 0 || d.height <= 0) {
         d = this.getPreferredSize();
       }
-      model.getGraphLayout().setSize(d);
+      model.getLayoutMediator().getLayout().setSize(d);
     }
   }
 
@@ -288,7 +288,7 @@ public class BasicVisualizationServer<V, E> extends JPanel
       renderContext.getGraphicsContext().setDelegate(g2d);
     }
     renderContext.setScreenDevice(this);
-    Layout<V> layout = model.getGraphLayout();
+    Layout<V> layout = model.getLayoutMediator().getLayout();
 
     g2d.setRenderingHints(renderingHints);
 
@@ -322,7 +322,7 @@ public class BasicVisualizationServer<V, E> extends JPanel
       ((Caching) layout).clear();
     }
 
-    renderer.render();
+    renderer.render(renderContext, model.getLayoutMediator());
 
     // if there are postRenderers set, do it
     for (Paintable paintable : postRenderers) {

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/DefaultVisualizationModel.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/DefaultVisualizationModel.java
@@ -38,13 +38,9 @@ public class DefaultVisualizationModel<N, E>
   protected Relaxer relaxer;
 
   protected LayoutMediator<N, E> layoutMediator;
-  /** the layout algorithm currently in use */
-  //  protected Layout<N> layout;
 
   /** listens for changes in the layout, forwards to the viewer */
   protected ChangeListener changeListener;
-
-  //  private final Network<N, E> network;
 
   /** @param layout The Layout to apply, with its associated Network */
   public DefaultVisualizationModel(Network<N, E> network, Layout<N> layout) {
@@ -137,15 +133,6 @@ public class DefaultVisualizationModel<N, E>
   public void setGraphLayout(Layout<N> layout) {
     setGraphLayout(layout, null);
   }
-
-  //  /** Returns the current graph layout. */
-  //  public Layout<N> getGraphLayout() {
-  //    return this.layoutMediator.getLayout();
-  //  }
-  //
-  //  public Network<N, E> getNetwork() {
-  //    return this.layoutMediator.getNetwork();
-  //  }
 
   /** @return the relaxer */
   public Relaxer getRelaxer() {

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/DefaultVisualizationModel.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/DefaultVisualizationModel.java
@@ -17,6 +17,7 @@ import edu.uci.ics.jung.algorithms.util.IterativeContext;
 import edu.uci.ics.jung.visualization.layout.ObservableCachingLayout;
 import edu.uci.ics.jung.visualization.util.ChangeEventSupport;
 import edu.uci.ics.jung.visualization.util.DefaultChangeEventSupport;
+import edu.uci.ics.jung.visualization.util.LayoutMediator;
 import java.awt.Dimension;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -36,13 +37,14 @@ public class DefaultVisualizationModel<N, E>
   /** manages the thread that applies the current layout algorithm */
   protected Relaxer relaxer;
 
+  protected LayoutMediator<N, E> layoutMediator;
   /** the layout algorithm currently in use */
-  protected Layout<N> layout;
+  //  protected Layout<N> layout;
 
   /** listens for changes in the layout, forwards to the viewer */
   protected ChangeListener changeListener;
 
-  private final Network<N, E> network;
+  //  private final Network<N, E> network;
 
   /** @param layout The Layout to apply, with its associated Network */
   public DefaultVisualizationModel(Network<N, E> network, Layout<N> layout) {
@@ -56,7 +58,8 @@ public class DefaultVisualizationModel<N, E>
    * @param d The preferred size of the View that will display this graph
    */
   public DefaultVisualizationModel(Network<N, E> network, Layout<N> layout, Dimension d) {
-    this.network = network;
+    this.layoutMediator = new LayoutMediator<>(network, layout);
+    //    this.network = network;
     if (changeListener == null) {
       changeListener =
           new ChangeListener() {
@@ -75,18 +78,25 @@ public class DefaultVisualizationModel<N, E>
    * @param viewSize the size of the View that will display this layout
    */
   public void setGraphLayout(Layout<N> layout, Dimension viewSize) {
+
+    Layout<N> currentLayout = this.layoutMediator.getLayout();
     // remove listener from old layout
-    if (this.layout != null && this.layout instanceof ChangeEventSupport) {
-      ((ChangeEventSupport) this.layout).removeChangeListener(changeListener);
+    if (currentLayout != null && currentLayout instanceof ChangeEventSupport) {
+      ((ChangeEventSupport) currentLayout).removeChangeListener(changeListener);
     }
+    Network<N, E> currentNetwork = this.layoutMediator.getNetwork();
     // set to new layout
     if (layout instanceof ChangeEventSupport) {
-      this.layout = layout;
+      this.layoutMediator = new LayoutMediator(currentNetwork, layout);
+      //      this.layout = layout;
     } else {
-      this.layout = new ObservableCachingLayout<N>(network.asGraph(), layout);
+      this.layoutMediator =
+          new LayoutMediator(
+              currentNetwork, new ObservableCachingLayout<N, E>(currentNetwork, layout));
+      //      this.layout = new ObservableCachingLayout<N>(network.asGraph(), layout);
     }
 
-    ((ChangeEventSupport) this.layout).addChangeListener(changeListener);
+    ((ChangeEventSupport) this.layoutMediator.getLayout()).addChangeListener(changeListener);
 
     if (viewSize == null) {
       viewSize = new Dimension(600, 600);
@@ -107,13 +117,17 @@ public class DefaultVisualizationModel<N, E>
     if (layout instanceof IterativeContext) {
       layout.initialize();
       if (relaxer == null) {
-        relaxer = new VisRunner((IterativeContext) this.layout);
+        relaxer = new VisRunner((IterativeContext) layout);
         //            	relaxer = new VisRunner((IterativeContext) decoratedLayout);
         relaxer.prerelax();
         relaxer.relax();
       }
     }
     fireStateChanged();
+  }
+
+  public LayoutMediator<N, E> getLayoutMediator() {
+    return layoutMediator;
   }
 
   /**
@@ -124,14 +138,14 @@ public class DefaultVisualizationModel<N, E>
     setGraphLayout(layout, null);
   }
 
-  /** Returns the current graph layout. */
-  public Layout<N> getGraphLayout() {
-    return layout;
-  }
-
-  public Network<N, E> getNetwork() {
-    return network;
-  }
+  //  /** Returns the current graph layout. */
+  //  public Layout<N> getGraphLayout() {
+  //    return this.layoutMediator.getLayout();
+  //  }
+  //
+  //  public Network<N, E> getNetwork() {
+  //    return this.layoutMediator.getNetwork();
+  //  }
 
   /** @return the relaxer */
   public Relaxer getRelaxer() {

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/VisualizationModel.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/VisualizationModel.java
@@ -43,12 +43,7 @@ public interface VisualizationModel<V, E> extends ChangeEventSupport {
    */
   void setGraphLayout(Layout<V> layout, Dimension d);
 
-  /** @return the current graph layout */
-  //  Layout<V> getGraphLayout();
-
   LayoutMediator<V, E> getLayoutMediator();
-
-  //  Network<V, E> getNetwork();
 
   /**
    * Register <code>l</code> as a listeners to changes in the model. The View registers in order to

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/VisualizationModel.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/VisualizationModel.java
@@ -10,10 +10,10 @@
 
 package edu.uci.ics.jung.visualization;
 
-import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.algorithms.layout.util.Relaxer;
 import edu.uci.ics.jung.visualization.util.ChangeEventSupport;
+import edu.uci.ics.jung.visualization.util.LayoutMediator;
 import java.awt.Dimension;
 import javax.swing.event.ChangeListener;
 
@@ -44,9 +44,11 @@ public interface VisualizationModel<V, E> extends ChangeEventSupport {
   void setGraphLayout(Layout<V> layout, Dimension d);
 
   /** @return the current graph layout */
-  Layout<V> getGraphLayout();
+  //  Layout<V> getGraphLayout();
 
-  Network<V, E> getNetwork();
+  LayoutMediator<V, E> getLayoutMediator();
+
+  //  Network<V, E> getNetwork();
 
   /**
    * Register <code>l</code> as a listeners to changes in the model. The View registers in order to

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/control/EditingPopupGraphMousePlugin.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/control/EditingPopupGraphMousePlugin.java
@@ -31,7 +31,8 @@ public class EditingPopupGraphMousePlugin<V, E> extends AbstractPopupGraphMouseP
   @SuppressWarnings({"unchecked", "serial"})
   protected void handlePopup(MouseEvent e) {
     final VisualizationViewer<V, E> vv = (VisualizationViewer<V, E>) e.getSource();
-    final MutableNetwork<V, E> graph = (MutableNetwork<V, E>) vv.getModel().getNetwork();
+    final MutableNetwork<V, E> graph =
+        (MutableNetwork<V, E>) vv.getModel().getLayoutMediator().getNetwork();
     final Point2D p = e.getPoint();
     NetworkElementAccessor<V, E> pickSupport = vv.getPickSupport();
     if (pickSupport != null) {

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/control/SimpleEdgeSupport.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/control/SimpleEdgeSupport.java
@@ -24,7 +24,7 @@ public class SimpleEdgeSupport<V, E> implements EdgeSupport<V, E> {
     this.startVertex = startVertex;
     this.down = startPoint;
     this.edgeEffects.startEdgeEffects(vv, startPoint, startPoint);
-    if (vv.getModel().getNetwork().isDirected()) {
+    if (vv.getModel().getLayoutMediator().getNetwork().isDirected()) {
       this.edgeEffects.startArrowEffects(vv, startPoint, startPoint);
     }
     vv.repaint();
@@ -34,7 +34,7 @@ public class SimpleEdgeSupport<V, E> implements EdgeSupport<V, E> {
   public void midEdgeCreate(BasicVisualizationServer<V, E> vv, Point2D midPoint) {
     if (startVertex != null) {
       this.edgeEffects.midEdgeEffects(vv, down, midPoint);
-      if (vv.getModel().getNetwork().isDirected()) {
+      if (vv.getModel().getLayoutMediator().getNetwork().isDirected()) {
         this.edgeEffects.midArrowEffects(vv, down, midPoint);
       }
       vv.repaint();
@@ -44,9 +44,11 @@ public class SimpleEdgeSupport<V, E> implements EdgeSupport<V, E> {
   @Override
   public void endEdgeCreate(BasicVisualizationServer<V, E> vv, V endVertex) {
     Preconditions.checkState(
-        vv.getModel().getNetwork() instanceof MutableNetwork<?, ?>, "graph must be mutable");
+        vv.getModel().getLayoutMediator().getNetwork() instanceof MutableNetwork<?, ?>,
+        "graph must be mutable");
     if (startVertex != null) {
-      MutableNetwork<V, E> graph = (MutableNetwork<V, E>) vv.getModel().getNetwork();
+      MutableNetwork<V, E> graph =
+          (MutableNetwork<V, E>) vv.getModel().getLayoutMediator().getNetwork();
       graph.addEdge(startVertex, endVertex, edgeFactory.get());
       vv.repaint();
     }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/control/SimpleVertexSupport.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/control/SimpleVertexSupport.java
@@ -26,10 +26,12 @@ public class SimpleVertexSupport<V, E> implements VertexSupport<V, E> {
 
   public void startVertexCreate(BasicVisualizationServer<V, E> vv, Point2D point) {
     Preconditions.checkState(
-        vv.getModel().getNetwork() instanceof MutableNetwork<?, ?>, "graph must be mutable");
+        vv.getModel().getLayoutMediator().getNetwork() instanceof MutableNetwork<?, ?>,
+        "graph must be mutable");
     V newVertex = vertexFactory.get();
     Layout<V> layout = vv.getGraphLayout();
-    MutableNetwork<V, E> graph = (MutableNetwork<V, E>) vv.getModel().getNetwork();
+    MutableNetwork<V, E> graph =
+        (MutableNetwork<V, E>) vv.getModel().getLayoutMediator().getNetwork();
     graph.addNode(newVertex);
     layout.setLocation(
         newVertex, vv.getRenderContext().getMultiLayerTransformer().inverseTransform(point));

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/GradientEdgePaintTransformer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/decorators/GradientEdgePaintTransformer.java
@@ -43,7 +43,7 @@ public class GradientEdgePaintTransformer<N, E> implements Function<E, Paint> {
   public GradientEdgePaintTransformer(Color c1, Color c2, VisualizationViewer<N, E> vv) {
     this.c1 = c1;
     this.c2 = c2;
-    this.graph = vv.getModel().getNetwork();
+    this.graph = vv.getModel().getLayoutMediator().getNetwork();
     this.layout = vv.getGraphLayout();
     this.transformer =
         vv.getRenderContext().getMultiLayerTransformer().getTransformer(Layer.LAYOUT);

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/LayoutChangeListener.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/LayoutChangeListener.java
@@ -1,6 +1,6 @@
 package edu.uci.ics.jung.visualization.layout;
 
-public interface LayoutChangeListener<V> {
+public interface LayoutChangeListener<V, E> {
 
-  void layoutChanged(LayoutEvent<V> evt);
+  void layoutChanged(LayoutEvent<V, E> evt);
 }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/LayoutEvent.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/LayoutEvent.java
@@ -1,13 +1,13 @@
 package edu.uci.ics.jung.visualization.layout;
 
-import com.google.common.graph.Graph;
+import com.google.common.graph.Network;
 
-public class LayoutEvent<V> {
+public class LayoutEvent<V, E> {
 
   V vertex;
-  Graph<V> graph;
+  Network<V, E> graph;
 
-  public LayoutEvent(V vertex, Graph<V> graph) {
+  public LayoutEvent(V vertex, Network<V, E> graph) {
     this.vertex = vertex;
     this.graph = graph;
   }
@@ -20,11 +20,11 @@ public class LayoutEvent<V> {
     this.vertex = vertex;
   }
 
-  public Graph<V> getGraph() {
+  public Network<V, E> getGraph() {
     return graph;
   }
 
-  public void setGraph(Graph<V> graph) {
+  public void setGraph(Network<V, E> graph) {
     this.graph = graph;
   }
 }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/LayoutEventSupport.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/LayoutEventSupport.java
@@ -1,8 +1,8 @@
 package edu.uci.ics.jung.visualization.layout;
 
-public interface LayoutEventSupport<V> {
+public interface LayoutEventSupport<V, E> {
 
-  void addLayoutChangeListener(LayoutChangeListener<V> listener);
+  void addLayoutChangeListener(LayoutChangeListener<V, E> listener);
 
-  void removeLayoutChangeListener(LayoutChangeListener<V> listener);
+  void removeLayoutChangeListener(LayoutChangeListener<V, E> listener);
 }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/LayoutTransition.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/LayoutTransition.java
@@ -27,7 +27,8 @@ public class LayoutTransition<V, E> implements IterativeContext {
       Relaxer relaxer = new VisRunner((IterativeContext) endLayout);
       relaxer.prerelax();
     }
-    this.transitionLayout = new StaticLayout<V>(vv.getModel().getNetwork().asGraph(), startLayout);
+    this.transitionLayout =
+        new StaticLayout<V>(vv.getModel().getLayoutMediator().getNetwork().asGraph(), startLayout);
     vv.setGraphLayout(transitionLayout);
   }
 
@@ -36,7 +37,7 @@ public class LayoutTransition<V, E> implements IterativeContext {
   }
 
   public void step() {
-    for (V v : vv.getModel().getNetwork().nodes()) {
+    for (V v : vv.getModel().getLayoutMediator().getNetwork().nodes()) {
       Point2D tp = transitionLayout.apply(v);
       Point2D fp = endLayout.apply(v);
       double dx = (fp.getX() - tp.getX()) / (count - counter);

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/ObservableCachingLayout.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/layout/ObservableCachingLayout.java
@@ -13,7 +13,7 @@ package edu.uci.ics.jung.visualization.layout;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.graph.Graph;
+import com.google.common.graph.Network;
 import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.algorithms.layout.LayoutDecorator;
 import edu.uci.ics.jung.algorithms.util.IterativeContext;
@@ -34,18 +34,18 @@ import javax.swing.event.ChangeListener;
  * @see LayoutDecorator
  * @author Tom Nelson
  */
-public class ObservableCachingLayout<V> extends LayoutDecorator<V>
-    implements ChangeEventSupport, Caching, LayoutEventSupport<V> {
+public class ObservableCachingLayout<V, E> extends LayoutDecorator<V>
+    implements ChangeEventSupport, Caching, LayoutEventSupport<V, E> {
 
   protected ChangeEventSupport changeSupport = new DefaultChangeEventSupport(this);
-  protected Graph<V> graph;
+  protected Network<V, E> graph;
 
   protected LoadingCache<V, Point2D> locations;
 
-  private List<LayoutChangeListener<V>> layoutChangeListeners =
-      new ArrayList<LayoutChangeListener<V>>();
+  private List<LayoutChangeListener<V, E>> layoutChangeListeners =
+      new ArrayList<LayoutChangeListener<V, E>>();
 
-  public ObservableCachingLayout(Graph<V> graph, Layout<V> delegate) {
+  public ObservableCachingLayout(Network<V, E> graph, Layout<V> delegate) {
     super(delegate);
     this.graph = graph;
     Function<V, Point2D> chain = delegate.andThen(p -> (Point2D) p.clone());
@@ -104,17 +104,17 @@ public class ObservableCachingLayout<V> extends LayoutDecorator<V>
   }
 
   private void fireLayoutChanged(V v) {
-    LayoutEvent<V> evt = new LayoutEvent<V>(v, graph);
-    for (LayoutChangeListener<V> listener : layoutChangeListeners) {
+    LayoutEvent<V, E> evt = new LayoutEvent<V, E>(v, graph);
+    for (LayoutChangeListener<V, E> listener : layoutChangeListeners) {
       listener.layoutChanged(evt);
     }
   }
 
-  public void addLayoutChangeListener(LayoutChangeListener<V> listener) {
+  public void addLayoutChangeListener(LayoutChangeListener<V, E> listener) {
     layoutChangeListeners.add(listener);
   }
 
-  public void removeLayoutChangeListener(LayoutChangeListener<V> listener) {
+  public void removeLayoutChangeListener(LayoutChangeListener<V, E> listener) {
     layoutChangeListeners.remove(listener);
   }
 

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/picking/ClosestShapePickSupport.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/picking/ClosestShapePickSupport.java
@@ -78,7 +78,7 @@ public class ClosestShapePickSupport<V, E> implements NetworkElementAccessor<V, 
     V closest = null;
     while (true) {
       try {
-        for (V v : vv.getModel().getNetwork().nodes()) {
+        for (V v : vv.getModel().getLayoutMediator().getNetwork().nodes()) {
           Point2D p = layout.apply(v);
           double dx = p.getX() - x;
           double dy = p.getY() - y;

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/picking/LayoutLensShapePickSupport.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/picking/LayoutLensShapePickSupport.java
@@ -119,7 +119,7 @@ public class LayoutLensShapePickSupport<V, E> extends ShapePickSupport<V, E> {
   public E getEdge(double x, double y) {
 
     Layout<V> layout = vv.getGraphLayout();
-    Network<V, E> network = vv.getModel().getNetwork();
+    Network<V, E> network = vv.getModel().getLayoutMediator().getNetwork();
     Point2D ip =
         vv.getRenderContext()
             .getMultiLayerTransformer()

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/picking/ShapePickSupport.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/picking/ShapePickSupport.java
@@ -318,7 +318,7 @@ public class ShapePickSupport<V, E> implements NetworkElementAccessor<V, E> {
    * @return the transformed shape
    */
   private Shape getTransformedEdgeShape(E e) {
-    EndpointPair<V> endpoints = vv.getModel().getNetwork().incidentNodes(e);
+    EndpointPair<V> endpoints = vv.getModel().getLayoutMediator().getNetwork().incidentNodes(e);
     V v1 = endpoints.nodeU();
     V v2 = endpoints.nodeV();
     boolean isLoop = v1.equals(v2);
@@ -363,14 +363,14 @@ public class ShapePickSupport<V, E> implements NetworkElementAccessor<V, E> {
   }
 
   protected Collection<V> getFilteredVertices() {
-    Set<V> nodes = vv.getModel().getNetwork().nodes();
+    Set<V> nodes = vv.getModel().getLayoutMediator().getNetwork().nodes();
     return verticesAreFiltered()
         ? Sets.filter(nodes, vv.getRenderContext().getVertexIncludePredicate()::test)
         : nodes;
   }
 
   protected Collection<E> getFilteredEdges() {
-    Set<E> edges = vv.getModel().getNetwork().edges();
+    Set<E> edges = vv.getModel().getLayoutMediator().getNetwork().edges();
     return edgesAreFiltered()
         ? Sets.filter(edges, vv.getRenderContext().getEdgeIncludePredicate()::test)
         : edges;
@@ -423,7 +423,7 @@ public class ShapePickSupport<V, E> implements NetworkElementAccessor<V, E> {
   protected boolean isEdgeRendered(E edge) {
     Predicate<V> vertexIncludePredicate = vv.getRenderContext().getVertexIncludePredicate();
     Predicate<E> edgeIncludePredicate = vv.getRenderContext().getEdgeIncludePredicate();
-    Network<V, E> g = vv.getModel().getNetwork();
+    Network<V, E> g = vv.getModel().getLayoutMediator().getNetwork();
     if (edgeIncludePredicate != null && !edgeIncludePredicate.test(edge)) {
       return false;
     }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/picking/ViewLensShapePickSupport.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/picking/ViewLensShapePickSupport.java
@@ -173,7 +173,7 @@ public class ViewLensShapePickSupport<V, E> extends ShapePickSupport<V, E> {
     while (true) {
       try {
         Layout<V> layout = vv.getGraphLayout();
-        Network<V, E> network = vv.getModel().getNetwork();
+        Network<V, E> network = vv.getModel().getLayoutMediator().getNetwork();
         for (E e : getFilteredEdges()) {
           EndpointPair<V> endpoints = network.incidentNodes(e);
           V v1 = endpoints.nodeU();

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicEdgeLabelRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicEdgeLabelRenderer.java
@@ -23,13 +23,6 @@ import java.awt.geom.Point2D;
 import java.util.function.Predicate;
 
 public class BasicEdgeLabelRenderer<V, E> implements Renderer.EdgeLabel<V, E> {
-  //  private final Layout<V> layout;
-  //  private final RenderContext<V, E> renderContext;
-  //
-  //  public BasicEdgeLabelRenderer(Layout<V> layout, RenderContext<V, E> renderContext) {
-  //    this.layout = layout;
-  //    this.renderContext = renderContext;
-  //  }
 
   public Component prepareRenderer(
       RenderContext<V, E> renderContext,

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicEdgeLabelRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicEdgeLabelRenderer.java
@@ -10,10 +10,10 @@
 package edu.uci.ics.jung.visualization.renderers;
 
 import com.google.common.graph.EndpointPair;
-import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.visualization.Layer;
 import edu.uci.ics.jung.visualization.RenderContext;
 import edu.uci.ics.jung.visualization.transform.shape.GraphicsDecorator;
+import edu.uci.ics.jung.visualization.util.LayoutMediator;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Shape;
@@ -23,16 +23,21 @@ import java.awt.geom.Point2D;
 import java.util.function.Predicate;
 
 public class BasicEdgeLabelRenderer<V, E> implements Renderer.EdgeLabel<V, E> {
-  private final Layout<V> layout;
-  private final RenderContext<V, E> renderContext;
-
-  public BasicEdgeLabelRenderer(Layout<V> layout, RenderContext<V, E> renderContext) {
-    this.layout = layout;
-    this.renderContext = renderContext;
-  }
+  //  private final Layout<V> layout;
+  //  private final RenderContext<V, E> renderContext;
+  //
+  //  public BasicEdgeLabelRenderer(Layout<V> layout, RenderContext<V, E> renderContext) {
+  //    this.layout = layout;
+  //    this.renderContext = renderContext;
+  //  }
 
   public Component prepareRenderer(
-      EdgeLabelRenderer graphLabelRenderer, Object value, boolean isSelected, E edge) {
+      RenderContext<V, E> renderContext,
+      LayoutMediator<V, E> layoutMediator,
+      EdgeLabelRenderer graphLabelRenderer,
+      Object value,
+      boolean isSelected,
+      E edge) {
     return renderContext
         .getEdgeLabelRenderer()
         .<E>getEdgeLabelRendererComponent(
@@ -44,7 +49,8 @@ public class BasicEdgeLabelRenderer<V, E> implements Renderer.EdgeLabel<V, E> {
   }
 
   @Override
-  public void labelEdge(E e, String label) {
+  public void labelEdge(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, E e, String label) {
     if (label == null || label.length() == 0) {
       return;
     }
@@ -58,8 +64,8 @@ public class BasicEdgeLabelRenderer<V, E> implements Renderer.EdgeLabel<V, E> {
       return;
     }
 
-    Point2D p1 = layout.apply(v1);
-    Point2D p2 = layout.apply(v2);
+    Point2D p1 = layoutMediator.getLayout().apply(v1);
+    Point2D p2 = layoutMediator.getLayout().apply(v2);
     p1 = renderContext.getMultiLayerTransformer().transform(Layer.LAYOUT, p1);
     p2 = renderContext.getMultiLayerTransformer().transform(Layer.LAYOUT, p2);
     float x1 = (float) p1.getX();
@@ -82,6 +88,8 @@ public class BasicEdgeLabelRenderer<V, E> implements Renderer.EdgeLabel<V, E> {
 
     Component component =
         prepareRenderer(
+            renderContext,
+            layoutMediator,
             renderContext.getEdgeLabelRenderer(),
             label,
             renderContext.getPickedEdgeState().isPicked(e),

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicEdgeRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicEdgeRenderer.java
@@ -11,7 +11,6 @@ package edu.uci.ics.jung.visualization.renderers;
 
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.Network;
-import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.graph.util.EdgeIndexFunction;
 import edu.uci.ics.jung.visualization.Layer;
 import edu.uci.ics.jung.visualization.RenderContext;
@@ -20,6 +19,7 @@ import edu.uci.ics.jung.visualization.decorators.ParallelEdgeShapeTransformer;
 import edu.uci.ics.jung.visualization.transform.LensTransformer;
 import edu.uci.ics.jung.visualization.transform.MutableTransformer;
 import edu.uci.ics.jung.visualization.transform.shape.GraphicsDecorator;
+import edu.uci.ics.jung.visualization.util.LayoutMediator;
 import java.awt.Dimension;
 import java.awt.Paint;
 import java.awt.Rectangle;
@@ -33,19 +33,20 @@ import java.util.function.Predicate;
 import javax.swing.JComponent;
 
 public class BasicEdgeRenderer<V, E> implements Renderer.Edge<V, E> {
-  protected final Layout<V> layout;
-  protected final RenderContext<V, E> renderContext;
+  //  protected final Layout<V> layout;
+  //  protected final RenderContext<V, E> renderContext;
 
-  public BasicEdgeRenderer(Layout<V> layout, RenderContext<V, E> rc) {
-    this.layout = layout;
-    this.renderContext = rc;
-  }
+  //  public BasicEdgeRenderer(Layout<V> layout, RenderContext<V, E> rc) {
+  //    this.layout = layout;
+  //    this.renderContext = rc;
+  //  }
 
   protected EdgeArrowRenderingSupport<V, E> edgeArrowRenderingSupport =
       new BasicEdgeArrowRenderingSupport<V, E>();
 
   @Override
-  public void paintEdge(E e) {
+  public void paintEdge(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, E e) {
     GraphicsDecorator g2d = renderContext.getGraphicsContext();
     if (!renderContext.getEdgeIncludePredicate().test(e)) {
       return;
@@ -66,7 +67,7 @@ public class BasicEdgeRenderer<V, E> implements Renderer.Edge<V, E> {
       g2d.setStroke(new_stroke);
     }
 
-    drawSimpleEdge(e);
+    drawSimpleEdge(renderContext, layoutMediator, e);
 
     // restore paint and stroke
     if (new_stroke != null) {
@@ -74,13 +75,18 @@ public class BasicEdgeRenderer<V, E> implements Renderer.Edge<V, E> {
     }
   }
 
-  protected Shape prepareFinalEdgeShape(E e, int[] coords, boolean[] loop) {
+  protected Shape prepareFinalEdgeShape(
+      RenderContext<V, E> renderContext,
+      LayoutMediator<V, E> layoutMediator,
+      E e,
+      int[] coords,
+      boolean[] loop) {
     EndpointPair<V> endpoints = renderContext.getNetwork().incidentNodes(e);
     V v1 = endpoints.nodeU();
     V v2 = endpoints.nodeV();
 
-    Point2D p1 = layout.apply(v1);
-    Point2D p2 = layout.apply(v2);
+    Point2D p1 = layoutMediator.getLayout().apply(v1);
+    Point2D p2 = layoutMediator.getLayout().apply(v2);
     p1 = renderContext.getMultiLayerTransformer().transform(Layer.LAYOUT, p1);
     p2 = renderContext.getMultiLayerTransformer().transform(Layer.LAYOUT, p2);
     float x1 = (float) p1.getX();
@@ -174,11 +180,12 @@ public class BasicEdgeRenderer<V, E> implements Renderer.Edge<V, E> {
    *
    * @param e the edge to be drawn
    */
-  protected void drawSimpleEdge(E e) {
+  protected void drawSimpleEdge(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, E e) {
 
     int[] coords = new int[4];
     boolean[] loop = new boolean[1];
-    Shape edgeShape = prepareFinalEdgeShape(e, coords, loop);
+    Shape edgeShape = prepareFinalEdgeShape(renderContext, layoutMediator, e, coords, loop);
 
     int x1 = coords[0];
     int y1 = coords[1];

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicEdgeRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicEdgeRenderer.java
@@ -33,13 +33,6 @@ import java.util.function.Predicate;
 import javax.swing.JComponent;
 
 public class BasicEdgeRenderer<V, E> implements Renderer.Edge<V, E> {
-  //  protected final Layout<V> layout;
-  //  protected final RenderContext<V, E> renderContext;
-
-  //  public BasicEdgeRenderer(Layout<V> layout, RenderContext<V, E> rc) {
-  //    this.layout = layout;
-  //    this.renderContext = rc;
-  //  }
 
   protected EdgeArrowRenderingSupport<V, E> edgeArrowRenderingSupport =
       new BasicEdgeArrowRenderingSupport<V, E>();

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicRenderer.java
@@ -8,8 +8,8 @@
 package edu.uci.ics.jung.visualization.renderers;
 
 import com.google.common.graph.Network;
-import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.visualization.RenderContext;
+import edu.uci.ics.jung.visualization.util.LayoutMediator;
 import java.util.ConcurrentModificationException;
 
 /**
@@ -22,31 +22,31 @@ import java.util.ConcurrentModificationException;
  */
 public class BasicRenderer<V, E> implements Renderer<V, E> {
 
-  protected Renderer.Vertex<V> vertexRenderer;
-  protected Renderer.VertexLabel<V> vertexLabelRenderer;
-  protected Renderer.Edge<V, E> edgeRenderer;
-  protected Renderer.EdgeLabel<V, E> edgeLabelRenderer;
+  protected Renderer.Vertex<V, E> vertexRenderer = new BasicVertexRenderer<V, E>();
+  protected Renderer.VertexLabel<V, E> vertexLabelRenderer = new BasicVertexLabelRenderer<V, E>();
+  protected Renderer.Edge<V, E> edgeRenderer = new BasicEdgeRenderer<V, E>();
+  protected Renderer.EdgeLabel<V, E> edgeLabelRenderer = new BasicEdgeLabelRenderer<V, E>();
 
-  protected final Layout<V> layout;
-  protected final RenderContext<V, E> renderContext;
+  //  protected final Layout<V> layout;
+  //  protected final RenderContext<V, E> renderContext;
 
-  public BasicRenderer(Layout<V> layout, RenderContext<V, E> rc) {
-    this.layout = layout;
-    this.renderContext = rc;
-    this.vertexRenderer = new BasicVertexRenderer<V>(layout, rc);
-    this.vertexLabelRenderer = new BasicVertexLabelRenderer<V>(layout, rc);
-    this.edgeRenderer = new BasicEdgeRenderer<V, E>(layout, rc);
-    this.edgeLabelRenderer = new BasicEdgeLabelRenderer<V, E>(layout, rc);
-  }
+  //  public BasicRenderer(Layout<V> layout, RenderContext<V, E> rc) {
+  //    this.layout = layout;
+  //    this.renderContext = rc;
+  //    this.vertexRenderer = new BasicVertexRenderer<V>(layout, rc);
+  //    this.vertexLabelRenderer = new BasicVertexLabelRenderer<V>(layout, rc);
+  //    this.edgeRenderer = new BasicEdgeRenderer<V, E>(layout, rc);
+  //    this.edgeLabelRenderer = new BasicEdgeLabelRenderer<V, E>(layout, rc);
+  //  }
 
   @Override
-  public void render() {
+  public void render(RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator) {
     Network<V, E> network = renderContext.getNetwork();
     // paint all the edges
     try {
       for (E e : network.edges()) {
-        renderEdge(e);
-        renderEdgeLabel(e);
+        renderEdge(renderContext, layoutMediator, e);
+        renderEdgeLabel(renderContext, layoutMediator, e);
       }
     } catch (ConcurrentModificationException cme) {
       renderContext.getScreenDevice().repaint();
@@ -55,31 +55,37 @@ public class BasicRenderer<V, E> implements Renderer<V, E> {
     // paint all the vertices
     try {
       for (V v : network.nodes()) {
-        renderVertex(v);
-        renderVertexLabel(v);
+        renderVertex(renderContext, layoutMediator, v);
+        renderVertexLabel(renderContext, layoutMediator, v);
       }
     } catch (ConcurrentModificationException cme) {
       renderContext.getScreenDevice().repaint();
     }
   }
 
-  public void renderVertex(V v) {
-    vertexRenderer.paintVertex(v);
+  public void renderVertex(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v) {
+    vertexRenderer.paintVertex(renderContext, layoutMediator, v);
   }
 
-  public void renderVertexLabel(V v) {
-    vertexLabelRenderer.labelVertex(v, renderContext.getVertexLabelTransformer().apply(v));
+  public void renderVertexLabel(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v) {
+    vertexLabelRenderer.labelVertex(
+        renderContext, layoutMediator, v, renderContext.getVertexLabelTransformer().apply(v));
   }
 
-  public void renderEdge(E e) {
-    edgeRenderer.paintEdge(e);
+  public void renderEdge(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, E e) {
+    edgeRenderer.paintEdge(renderContext, layoutMediator, e);
   }
 
-  public void renderEdgeLabel(E e) {
-    edgeLabelRenderer.labelEdge(e, renderContext.getEdgeLabelTransformer().apply(e));
+  public void renderEdgeLabel(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, E e) {
+    edgeLabelRenderer.labelEdge(
+        renderContext, layoutMediator, e, renderContext.getEdgeLabelTransformer().apply(e));
   }
 
-  public void setVertexRenderer(Renderer.Vertex<V> r) {
+  public void setVertexRenderer(Renderer.Vertex<V, E> r) {
     this.vertexRenderer = r;
   }
 
@@ -98,12 +104,12 @@ public class BasicRenderer<V, E> implements Renderer<V, E> {
   }
 
   /** @return the vertexLabelRenderer */
-  public Renderer.VertexLabel<V> getVertexLabelRenderer() {
+  public Renderer.VertexLabel<V, E> getVertexLabelRenderer() {
     return vertexLabelRenderer;
   }
 
   /** @param vertexLabelRenderer the vertexLabelRenderer to set */
-  public void setVertexLabelRenderer(Renderer.VertexLabel<V> vertexLabelRenderer) {
+  public void setVertexLabelRenderer(Renderer.VertexLabel<V, E> vertexLabelRenderer) {
     this.vertexLabelRenderer = vertexLabelRenderer;
   }
 
@@ -113,7 +119,7 @@ public class BasicRenderer<V, E> implements Renderer<V, E> {
   }
 
   /** @return the vertexRenderer */
-  public Renderer.Vertex<V> getVertexRenderer() {
+  public Renderer.Vertex<V, E> getVertexRenderer() {
     return vertexRenderer;
   }
 }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicRenderer.java
@@ -27,18 +27,6 @@ public class BasicRenderer<V, E> implements Renderer<V, E> {
   protected Renderer.Edge<V, E> edgeRenderer = new BasicEdgeRenderer<V, E>();
   protected Renderer.EdgeLabel<V, E> edgeLabelRenderer = new BasicEdgeLabelRenderer<V, E>();
 
-  //  protected final Layout<V> layout;
-  //  protected final RenderContext<V, E> renderContext;
-
-  //  public BasicRenderer(Layout<V> layout, RenderContext<V, E> rc) {
-  //    this.layout = layout;
-  //    this.renderContext = rc;
-  //    this.vertexRenderer = new BasicVertexRenderer<V>(layout, rc);
-  //    this.vertexLabelRenderer = new BasicVertexLabelRenderer<V>(layout, rc);
-  //    this.edgeRenderer = new BasicEdgeRenderer<V, E>(layout, rc);
-  //    this.edgeLabelRenderer = new BasicEdgeLabelRenderer<V, E>(layout, rc);
-  //  }
-
   @Override
   public void render(RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator) {
     Network<V, E> network = renderContext.getNetwork();

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicVertexLabelRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicVertexLabelRenderer.java
@@ -28,13 +28,6 @@ public class BasicVertexLabelRenderer<V, E> implements Renderer.VertexLabel<V, E
 
   protected Position position = Position.SE;
   private Positioner positioner = new OutsidePositioner();
-  //  protected final Layout<V> layout;
-  //  protected final RenderContext<V, ?> renderContext;
-  //
-  //  public BasicVertexLabelRenderer(Layout<V> layout, RenderContext<V, ?> rc) {
-  //    this.layout = layout;
-  //    this.renderContext = rc;
-  //  }
 
   /** @return the position */
   public Position getPosition() {

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicVertexLabelRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicVertexLabelRenderer.java
@@ -9,13 +9,13 @@
  */
 package edu.uci.ics.jung.visualization.renderers;
 
-import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.visualization.Layer;
 import edu.uci.ics.jung.visualization.RenderContext;
 import edu.uci.ics.jung.visualization.transform.BidirectionalTransformer;
 import edu.uci.ics.jung.visualization.transform.shape.GraphicsDecorator;
 import edu.uci.ics.jung.visualization.transform.shape.ShapeTransformer;
 import edu.uci.ics.jung.visualization.transform.shape.TransformingGraphics;
+import edu.uci.ics.jung.visualization.util.LayoutMediator;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Point;
@@ -24,17 +24,17 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
-public class BasicVertexLabelRenderer<V> implements Renderer.VertexLabel<V> {
+public class BasicVertexLabelRenderer<V, E> implements Renderer.VertexLabel<V, E> {
 
   protected Position position = Position.SE;
   private Positioner positioner = new OutsidePositioner();
-  protected final Layout<V> layout;
-  protected final RenderContext<V, ?> renderContext;
-
-  public BasicVertexLabelRenderer(Layout<V> layout, RenderContext<V, ?> rc) {
-    this.layout = layout;
-    this.renderContext = rc;
-  }
+  //  protected final Layout<V> layout;
+  //  protected final RenderContext<V, ?> renderContext;
+  //
+  //  public BasicVertexLabelRenderer(Layout<V> layout, RenderContext<V, ?> rc) {
+  //    this.layout = layout;
+  //    this.renderContext = rc;
+  //  }
 
   /** @return the position */
   public Position getPosition() {
@@ -47,7 +47,12 @@ public class BasicVertexLabelRenderer<V> implements Renderer.VertexLabel<V> {
   }
 
   public Component prepareRenderer(
-      VertexLabelRenderer graphLabelRenderer, Object value, boolean isSelected, V vertex) {
+      RenderContext<V, E> renderContext,
+      LayoutMediator<V, E> layoutMediator,
+      VertexLabelRenderer graphLabelRenderer,
+      Object value,
+      boolean isSelected,
+      V vertex) {
     return renderContext
         .getVertexLabelRenderer()
         .<V>getVertexLabelRendererComponent(
@@ -64,11 +69,12 @@ public class BasicVertexLabelRenderer<V> implements Renderer.VertexLabel<V> {
    * the graphics context is used.) If vertex label centering is active, the label is centered on
    * the position of the vertex; otherwise the label is offset slightly.
    */
-  public void labelVertex(V v, String label) {
+  public void labelVertex(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v, String label) {
     if (!renderContext.getVertexIncludePredicate().test(v)) {
       return;
     }
-    Point2D pt = layout.apply(v);
+    Point2D pt = layoutMediator.getLayout().apply(v);
     pt = renderContext.getMultiLayerTransformer().transform(Layer.LAYOUT, pt);
 
     float x = (float) pt.getX();
@@ -76,6 +82,8 @@ public class BasicVertexLabelRenderer<V> implements Renderer.VertexLabel<V> {
 
     Component component =
         prepareRenderer(
+            renderContext,
+            layoutMediator,
             renderContext.getVertexLabelRenderer(),
             label,
             renderContext.getPickedVertexState().isPicked(v),

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicVertexRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicVertexRenderer.java
@@ -26,13 +26,6 @@ import javax.swing.Icon;
 import javax.swing.JComponent;
 
 public class BasicVertexRenderer<V, E> implements Renderer.Vertex<V, E> {
-  //  protected final Layout<V> layout;
-  //  protected final RenderContext<V, ?> renderContext;
-
-  //  public BasicVertexRenderer(Layout<V> layout, RenderContext<V, ?> rc) {
-  //    this.layout = layout;
-  //    this.renderContext = rc;
-  //  }
 
   public void paintVertex(
       RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v) {

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/CachingEdgeRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/CachingEdgeRenderer.java
@@ -32,10 +32,6 @@ public class CachingEdgeRenderer<V, E> extends BasicEdgeRenderer<V, E>
   protected Map<E, Shape> edgeShapeMap = new HashMap<E, Shape>();
   protected Set<E> dirtyEdges = new HashSet<E>();
 
-  //  public CachingEdgeRenderer(Layout<V> layout, RenderContext<V, E> rc) {
-  //    super(layout, rc);
-  //  }
-
   @SuppressWarnings({"rawtypes", "unchecked"})
   public CachingEdgeRenderer(BasicVisualizationServer<V, E> vv) {
     //    super(vv.getGraphLayout(), vv.getRenderContext());

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/CachingEdgeRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/CachingEdgeRenderer.java
@@ -11,6 +11,7 @@ import edu.uci.ics.jung.visualization.layout.LayoutEventSupport;
 import edu.uci.ics.jung.visualization.transform.LensTransformer;
 import edu.uci.ics.jung.visualization.transform.MutableTransformer;
 import edu.uci.ics.jung.visualization.transform.shape.GraphicsDecorator;
+import edu.uci.ics.jung.visualization.util.LayoutMediator;
 import java.awt.Dimension;
 import java.awt.Paint;
 import java.awt.Rectangle;
@@ -26,18 +27,18 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
 public class CachingEdgeRenderer<V, E> extends BasicEdgeRenderer<V, E>
-    implements ChangeListener, LayoutChangeListener<V> {
+    implements ChangeListener, LayoutChangeListener<V, E> {
 
   protected Map<E, Shape> edgeShapeMap = new HashMap<E, Shape>();
   protected Set<E> dirtyEdges = new HashSet<E>();
 
-  public CachingEdgeRenderer(Layout<V> layout, RenderContext<V, E> rc) {
-    super(layout, rc);
-  }
+  //  public CachingEdgeRenderer(Layout<V> layout, RenderContext<V, E> rc) {
+  //    super(layout, rc);
+  //  }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   public CachingEdgeRenderer(BasicVisualizationServer<V, E> vv) {
-    super(vv.getGraphLayout(), vv.getRenderContext());
+    //    super(vv.getGraphLayout(), vv.getRenderContext());
     vv.getRenderContext().getMultiLayerTransformer().addChangeListener(this);
     Layout<V> layout = vv.getGraphLayout();
     if (layout instanceof LayoutEventSupport) {
@@ -51,14 +52,15 @@ public class CachingEdgeRenderer<V, E> extends BasicEdgeRenderer<V, E>
    * the distance between <code>(x1,y1)</code> and <code>(x2,y2)</code>.
    */
   @Override
-  protected void drawSimpleEdge(E e) {
+  protected void drawSimpleEdge(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, E e) {
 
     int[] coords = new int[4];
     boolean[] loop = new boolean[1];
 
     Shape edgeShape = edgeShapeMap.get(e);
     if (edgeShape == null || dirtyEdges.contains(e)) {
-      edgeShape = prepareFinalEdgeShape(e, coords, loop);
+      edgeShape = prepareFinalEdgeShape(renderContext, layoutMediator, e, coords, loop);
       edgeShapeMap.put(e, edgeShape);
       dirtyEdges.remove(e);
     }
@@ -190,9 +192,9 @@ public class CachingEdgeRenderer<V, E> extends BasicEdgeRenderer<V, E>
   }
 
   @Override
-  public void layoutChanged(LayoutEvent<V> evt) {
+  public void layoutChanged(LayoutEvent<V, E> evt) {
     V v = evt.getVertex();
-    Network<V, E> graph = renderContext.getNetwork();
+    Network<V, E> graph = evt.getGraph();
     dirtyEdges.addAll(graph.incidentEdges(v));
   }
 }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/CachingRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/CachingRenderer.java
@@ -1,7 +1,5 @@
 package edu.uci.ics.jung.visualization.renderers;
 
-import edu.uci.ics.jung.algorithms.layout.Layout;
-import edu.uci.ics.jung.visualization.RenderContext;
 import java.awt.Shape;
 import java.util.HashMap;
 import java.util.Map;
@@ -11,7 +9,7 @@ public class CachingRenderer<V, E> extends BasicRenderer<V, E> {
   protected Map<E, Shape> edgeShapeMap = new HashMap<E, Shape>();
   protected Map<V, Shape> vertexShapeMap = new HashMap<V, Shape>();
 
-  public CachingRenderer(Layout<V> layout, RenderContext<V, E> rc) {
-    super(layout, rc);
-  }
+  //  public CachingRenderer(Layout<V> layout, RenderContext<V, E> rc) {
+  //    super(layout, rc);
+  //  }
 }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/CachingRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/CachingRenderer.java
@@ -8,8 +8,4 @@ public class CachingRenderer<V, E> extends BasicRenderer<V, E> {
 
   protected Map<E, Shape> edgeShapeMap = new HashMap<E, Shape>();
   protected Map<V, Shape> vertexShapeMap = new HashMap<V, Shape>();
-
-  //  public CachingRenderer(Layout<V> layout, RenderContext<V, E> rc) {
-  //    super(layout, rc);
-  //  }
 }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/CachingVertexRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/CachingVertexRenderer.java
@@ -2,10 +2,12 @@ package edu.uci.ics.jung.visualization.renderers;
 
 import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.visualization.BasicVisualizationServer;
+import edu.uci.ics.jung.visualization.RenderContext;
 import edu.uci.ics.jung.visualization.layout.LayoutChangeListener;
 import edu.uci.ics.jung.visualization.layout.LayoutEvent;
 import edu.uci.ics.jung.visualization.layout.LayoutEventSupport;
 import edu.uci.ics.jung.visualization.transform.shape.GraphicsDecorator;
+import edu.uci.ics.jung.visualization.util.LayoutMediator;
 import java.awt.Shape;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -15,8 +17,8 @@ import javax.swing.Icon;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
-public class CachingVertexRenderer<V, E> extends BasicVertexRenderer<V>
-    implements ChangeListener, LayoutChangeListener<V> {
+public class CachingVertexRenderer<V, E> extends BasicVertexRenderer<V, E>
+    implements ChangeListener, LayoutChangeListener<V, E> {
 
   protected Map<V, Shape> vertexShapeMap = new HashMap<V, Shape>();
 
@@ -24,7 +26,7 @@ public class CachingVertexRenderer<V, E> extends BasicVertexRenderer<V>
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   public CachingVertexRenderer(BasicVisualizationServer<V, E> vv) {
-    super(vv.getGraphLayout(), vv.getRenderContext());
+    //    super(vv.getGraphLayout(), vv.getRenderContext());
     vv.getRenderContext().getMultiLayerTransformer().addChangeListener(this);
     Layout<V> layout = vv.getGraphLayout();
     if (layout instanceof LayoutEventSupport) {
@@ -33,17 +35,18 @@ public class CachingVertexRenderer<V, E> extends BasicVertexRenderer<V>
   }
 
   /** Paint <code>v</code>'s icon on <code>g</code> at <code>(x,y)</code>. */
-  protected void paintIconForVertex(V v) {
+  protected void paintIconForVertex(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v) {
     GraphicsDecorator g = renderContext.getGraphicsContext();
     boolean vertexHit = true;
     int[] coords = new int[2];
     Shape shape = vertexShapeMap.get(v);
     if (shape == null || dirtyVertices.contains(v)) {
-      shape = prepareFinalVertexShape(v, coords);
+      shape = prepareFinalVertexShape(renderContext, layoutMediator, v, coords);
       vertexShapeMap.put(v, shape);
       dirtyVertices.remove(v);
     }
-    vertexHit = vertexHit(shape);
+    vertexHit = vertexHit(renderContext, layoutMediator, shape);
     if (vertexHit) {
       if (renderContext.getVertexIconTransformer() != null) {
         Icon icon = renderContext.getVertexIconTransformer().apply(v);
@@ -52,10 +55,10 @@ public class CachingVertexRenderer<V, E> extends BasicVertexRenderer<V>
           g.draw(icon, renderContext.getScreenDevice(), shape, coords[0], coords[1]);
 
         } else {
-          paintShapeForVertex(v, shape);
+          paintShapeForVertex(renderContext, layoutMediator, v, shape);
         }
       } else {
-        paintShapeForVertex(v, shape);
+        paintShapeForVertex(renderContext, layoutMediator, v, shape);
       }
     }
   }
@@ -65,7 +68,7 @@ public class CachingVertexRenderer<V, E> extends BasicVertexRenderer<V>
     vertexShapeMap.clear();
   }
 
-  public void layoutChanged(LayoutEvent<V> evt) {
+  public void layoutChanged(LayoutEvent<V, E> evt) {
     this.dirtyVertices.add(evt.getVertex());
   }
 }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/CachingVertexRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/CachingVertexRenderer.java
@@ -26,7 +26,6 @@ public class CachingVertexRenderer<V, E> extends BasicVertexRenderer<V, E>
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   public CachingVertexRenderer(BasicVisualizationServer<V, E> vv) {
-    //    super(vv.getGraphLayout(), vv.getRenderContext());
     vv.getRenderContext().getMultiLayerTransformer().addChangeListener(this);
     Layout<V> layout = vv.getGraphLayout();
     if (layout instanceof LayoutEventSupport) {
@@ -64,7 +63,6 @@ public class CachingVertexRenderer<V, E> extends BasicVertexRenderer<V, E>
   }
 
   public void stateChanged(ChangeEvent evt) {
-    //		System.err.println("got change event "+evt);
     vertexShapeMap.clear();
   }
 

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/GradientVertexRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/GradientVertexRenderer.java
@@ -9,12 +9,12 @@
  */
 package edu.uci.ics.jung.visualization.renderers;
 
-import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.visualization.Layer;
 import edu.uci.ics.jung.visualization.RenderContext;
 import edu.uci.ics.jung.visualization.VisualizationServer;
 import edu.uci.ics.jung.visualization.picking.PickedState;
 import edu.uci.ics.jung.visualization.transform.shape.GraphicsDecorator;
+import edu.uci.ics.jung.visualization.util.LayoutMediator;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.GradientPaint;
@@ -33,7 +33,7 @@ import javax.swing.JComponent;
  * @param <V> the vertex type
  * @param <V> the edge type
  */
-public class GradientVertexRenderer<V> implements Renderer.Vertex<V> {
+public class GradientVertexRenderer<V, E> implements Renderer.Vertex<V, E> {
 
   Color colorOne;
   Color colorTwo;
@@ -41,16 +41,16 @@ public class GradientVertexRenderer<V> implements Renderer.Vertex<V> {
   Color pickedColorTwo;
   PickedState<V> pickedState;
   boolean cyclic;
-  protected final Layout<V> layout;
-  protected final RenderContext<V, ?> renderContext;
+  //  protected final Layout<V> layout;
+  //  protected final RenderContext<V, ?> renderContext;
 
   public GradientVertexRenderer(
       VisualizationServer<V, ?> vv, Color colorOne, Color colorTwo, boolean cyclic) {
     this.colorOne = colorOne;
     this.colorTwo = colorTwo;
     this.cyclic = cyclic;
-    this.layout = vv.getGraphLayout();
-    this.renderContext = vv.getRenderContext();
+    //    this.layout = vv.getGraphLayout();
+    //    this.renderContext = vv.getRenderContext();
   }
 
   public GradientVertexRenderer(
@@ -66,17 +66,18 @@ public class GradientVertexRenderer<V> implements Renderer.Vertex<V> {
     this.pickedColorTwo = pickedColorTwo;
     this.pickedState = vv.getPickedVertexState();
     this.cyclic = cyclic;
-    this.layout = vv.getGraphLayout();
-    this.renderContext = vv.getRenderContext();
+    //    this.layout = vv.getGraphLayout();
+    //    this.renderContext = vv.getRenderContext();
   }
 
-  public void paintVertex(V v) {
+  public void paintVertex(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v) {
     if (renderContext.getVertexIncludePredicate().test(v)) {
       boolean vertexHit = true;
       // get the shape to be rendered
       Shape shape = renderContext.getVertexShapeTransformer().apply(v);
 
-      Point2D p = layout.apply(v);
+      Point2D p = layoutMediator.getLayout().apply(v);
       p = renderContext.getMultiLayerTransformer().transform(Layer.LAYOUT, p);
 
       float x = (float) p.getX();
@@ -88,15 +89,16 @@ public class GradientVertexRenderer<V> implements Renderer.Vertex<V> {
       // transform the vertex shape with xtransform
       shape = xform.createTransformedShape(shape);
 
-      vertexHit = vertexHit(shape);
+      vertexHit = vertexHit(renderContext, layoutMediator, shape);
 
       if (vertexHit) {
-        paintShapeForVertex(v, shape);
+        paintShapeForVertex(renderContext, v, shape);
       }
     }
   }
 
-  protected boolean vertexHit(Shape s) {
+  protected boolean vertexHit(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, Shape s) {
     JComponent vv = renderContext.getScreenDevice();
     Rectangle deviceRectangle = null;
     if (vv != null) {
@@ -110,7 +112,7 @@ public class GradientVertexRenderer<V> implements Renderer.Vertex<V> {
         .intersects(deviceRectangle);
   }
 
-  protected void paintShapeForVertex(V v, Shape shape) {
+  protected void paintShapeForVertex(RenderContext<V, E> renderContext, V v, Shape shape) {
     GraphicsDecorator g = renderContext.getGraphicsContext();
     Paint oldPaint = g.getPaint();
     Rectangle r = shape.getBounds();

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/GradientVertexRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/GradientVertexRenderer.java
@@ -41,16 +41,12 @@ public class GradientVertexRenderer<V, E> implements Renderer.Vertex<V, E> {
   Color pickedColorTwo;
   PickedState<V> pickedState;
   boolean cyclic;
-  //  protected final Layout<V> layout;
-  //  protected final RenderContext<V, ?> renderContext;
 
   public GradientVertexRenderer(
       VisualizationServer<V, ?> vv, Color colorOne, Color colorTwo, boolean cyclic) {
     this.colorOne = colorOne;
     this.colorTwo = colorTwo;
     this.cyclic = cyclic;
-    //    this.layout = vv.getGraphLayout();
-    //    this.renderContext = vv.getRenderContext();
   }
 
   public GradientVertexRenderer(

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/Renderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/Renderer.java
@@ -9,6 +9,8 @@
  */
 package edu.uci.ics.jung.visualization.renderers;
 
+import edu.uci.ics.jung.visualization.RenderContext;
+import edu.uci.ics.jung.visualization.util.LayoutMediator;
 import java.awt.Dimension;
 
 /**
@@ -17,51 +19,54 @@ import java.awt.Dimension;
  */
 public interface Renderer<V, E> {
 
-  void render();
+  void render(RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator);
 
-  void renderVertex(V v);
+  void renderVertex(RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v);
 
-  void renderVertexLabel(V v);
+  void renderVertexLabel(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v);
 
-  void renderEdge(E e);
+  void renderEdge(RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, E e);
 
-  void renderEdgeLabel(E e);
+  void renderEdgeLabel(RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, E e);
 
-  void setVertexRenderer(Renderer.Vertex<V> r);
+  void setVertexRenderer(Renderer.Vertex<V, E> r);
 
   void setEdgeRenderer(Renderer.Edge<V, E> r);
 
-  void setVertexLabelRenderer(Renderer.VertexLabel<V> r);
+  void setVertexLabelRenderer(Renderer.VertexLabel<V, E> r);
 
   void setEdgeLabelRenderer(Renderer.EdgeLabel<V, E> r);
 
-  Renderer.VertexLabel<V> getVertexLabelRenderer();
+  Renderer.VertexLabel<V, E> getVertexLabelRenderer();
 
-  Renderer.Vertex<V> getVertexRenderer();
+  Renderer.Vertex<V, E> getVertexRenderer();
 
   Renderer.Edge<V, E> getEdgeRenderer();
 
   Renderer.EdgeLabel<V, E> getEdgeLabelRenderer();
 
-  interface Vertex<V> {
-    void paintVertex(V v);
+  interface Vertex<V, E> {
+    void paintVertex(RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v);
 
     @SuppressWarnings("rawtypes")
-    class NOOP implements Vertex {
-      public void paintVertex(Object v) {}
+    class NOOP<V, E> implements Vertex<V, E> {
+      public void paintVertex(
+          RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v) {}
     };
   }
 
   interface Edge<V, E> {
-    void paintEdge(E e);
+    void paintEdge(RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, E e);
 
     EdgeArrowRenderingSupport<V, E> getEdgeArrowRenderingSupport();
 
     void setEdgeArrowRenderingSupport(EdgeArrowRenderingSupport<V, E> edgeArrowRenderingSupport);
 
     @SuppressWarnings("rawtypes")
-    class NOOP implements Edge {
-      public void paintEdge(Object e) {}
+    class NOOP<V, E> implements Edge<V, E> {
+      public void paintEdge(
+          RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, E e) {}
 
       public EdgeArrowRenderingSupport getEdgeArrowRenderingSupport() {
         return null;
@@ -72,8 +77,9 @@ public interface Renderer<V, E> {
     }
   }
 
-  interface VertexLabel<V> {
-    void labelVertex(V v, String label);
+  interface VertexLabel<V, E> {
+    void labelVertex(
+        RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v, String label);
 
     Position getPosition();
 
@@ -84,8 +90,12 @@ public interface Renderer<V, E> {
     Positioner getPositioner();
 
     @SuppressWarnings("rawtypes")
-    class NOOP implements VertexLabel {
-      public void labelVertex(Object v, String label) {}
+    class NOOP<V, E> implements VertexLabel<V, E> {
+      public void labelVertex(
+          RenderContext<V, E> renderContext,
+          LayoutMediator<V, E> layoutMediator,
+          V v,
+          String label) {}
 
       public Position getPosition() {
         return Position.CNTR;
@@ -123,11 +133,16 @@ public interface Renderer<V, E> {
   }
 
   interface EdgeLabel<V, E> {
-    void labelEdge(E e, String label);
+    void labelEdge(
+        RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, E e, String label);
 
     @SuppressWarnings("rawtypes")
-    class NOOP implements EdgeLabel {
-      public void labelEdge(Object e, String label) {}
+    class NOOP<V, E> implements EdgeLabel<V, E> {
+      public void labelEdge(
+          RenderContext<V, E> renderContext,
+          LayoutMediator<V, E> layoutMediator,
+          E e,
+          String label) {}
     }
   }
 }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/ReshapingEdgeRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/ReshapingEdgeRenderer.java
@@ -11,12 +11,12 @@ package edu.uci.ics.jung.visualization.renderers;
 
 import com.google.common.graph.EndpointPair;
 import com.google.common.graph.Network;
-import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.visualization.Layer;
 import edu.uci.ics.jung.visualization.RenderContext;
 import edu.uci.ics.jung.visualization.transform.LensTransformer;
 import edu.uci.ics.jung.visualization.transform.MutableTransformer;
 import edu.uci.ics.jung.visualization.transform.shape.TransformingGraphics;
+import edu.uci.ics.jung.visualization.util.LayoutMediator;
 import java.awt.Dimension;
 import java.awt.Paint;
 import java.awt.Rectangle;
@@ -39,9 +39,9 @@ import javax.swing.JComponent;
 public class ReshapingEdgeRenderer<V, E> extends BasicEdgeRenderer<V, E>
     implements Renderer.Edge<V, E> {
 
-  public ReshapingEdgeRenderer(Layout<V> layout, RenderContext<V, E> rc) {
-    super(layout, rc);
-  }
+  //  public ReshapingEdgeRenderer(Layout<V> layout, RenderContext<V, E> rc) {
+  //    super(layout, rc);
+  //  }
 
   /**
    * Draws the edge <code>e</code>, whose endpoints are at <code>(x1,y1)</code> and <code>(x2,y2)
@@ -49,15 +49,16 @@ public class ReshapingEdgeRenderer<V, E> extends BasicEdgeRenderer<V, E>
    * EdgeShapeFunction</code> instance is scaled in the x-direction so that its width is equal to
    * the distance between <code>(x1,y1)</code> and <code>(x2,y2)</code>.
    */
-  protected void drawSimpleEdge(E e) {
+  protected void drawSimpleEdge(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, E e) {
 
     TransformingGraphics g = (TransformingGraphics) renderContext.getGraphicsContext();
     Network<V, E> graph = renderContext.getNetwork();
     EndpointPair<V> endpoints = graph.incidentNodes(e);
     V v1 = endpoints.nodeU();
     V v2 = endpoints.nodeV();
-    Point2D p1 = layout.apply(v1);
-    Point2D p2 = layout.apply(v2);
+    Point2D p1 = layoutMediator.getLayout().apply(v1);
+    Point2D p2 = layoutMediator.getLayout().apply(v2);
     p1 = renderContext.getMultiLayerTransformer().transform(Layer.LAYOUT, p1);
     p2 = renderContext.getMultiLayerTransformer().transform(Layer.LAYOUT, p2);
     float x1 = (float) p1.getX();

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/ReshapingEdgeRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/ReshapingEdgeRenderer.java
@@ -39,10 +39,6 @@ import javax.swing.JComponent;
 public class ReshapingEdgeRenderer<V, E> extends BasicEdgeRenderer<V, E>
     implements Renderer.Edge<V, E> {
 
-  //  public ReshapingEdgeRenderer(Layout<V> layout, RenderContext<V, E> rc) {
-  //    super(layout, rc);
-  //  }
-
   /**
    * Draws the edge <code>e</code>, whose endpoints are at <code>(x1,y1)</code> and <code>(x2,y2)
    * </code>, on the graphics context <code>g</code>. The <code>Shape</code> provided by the <code>

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/VertexLabelAsShapeRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/VertexLabelAsShapeRenderer.java
@@ -13,6 +13,7 @@ import edu.uci.ics.jung.algorithms.layout.Layout;
 import edu.uci.ics.jung.visualization.Layer;
 import edu.uci.ics.jung.visualization.RenderContext;
 import edu.uci.ics.jung.visualization.transform.shape.GraphicsDecorator;
+import edu.uci.ics.jung.visualization.util.LayoutMediator;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Rectangle;
@@ -31,7 +32,8 @@ import java.util.function.Function;
  * @param <V> the vertex type
  * @param <V> the edge type
  */
-public class VertexLabelAsShapeRenderer<V> implements Renderer.VertexLabel<V>, Function<V, Shape> {
+public class VertexLabelAsShapeRenderer<V, E>
+    implements Renderer.VertexLabel<V, E>, Function<V, Shape> {
 
   protected Map<V, Shape> shapes = new HashMap<V, Shape>();
   protected final Layout<V> layout;
@@ -64,7 +66,8 @@ public class VertexLabelAsShapeRenderer<V> implements Renderer.VertexLabel<V>, F
    * the graphics context is used.) If vertex label centering is active, the label is centered on
    * the position of the vertex; otherwise the label is offset slightly.
    */
-  public void labelVertex(V v, String label) {
+  public void labelVertex(
+      RenderContext<V, E> renderContext, LayoutMediator<V, E> layoutMediator, V v, String label) {
     if (!renderContext.getVertexIncludePredicate().test(v)) {
       return;
     }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/transform/shape/MagnifyImageLensSupport.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/transform/shape/MagnifyImageLensSupport.java
@@ -57,12 +57,11 @@ public class MagnifyImageLensSupport<V, E> extends AbstractLensSupport<V, E> {
     this.renderContext = vv.getRenderContext();
     this.pickSupport = renderContext.getPickSupport();
     this.renderer = vv.getRenderer();
-    this.transformingRenderer = new BasicRenderer<V, E>(vv.getGraphLayout(), renderContext);
+    this.transformingRenderer = new BasicRenderer<V, E>();
     this.savedGraphicsDecorator = renderContext.getGraphicsContext();
     this.lensTransformer = lensTransformer;
     this.savedEdgeRenderer = vv.getRenderer().getEdgeRenderer();
-    this.reshapingEdgeRenderer =
-        new ReshapingEdgeRenderer<V, E>(vv.getGraphLayout(), renderContext);
+    this.reshapingEdgeRenderer = new ReshapingEdgeRenderer<V, E>();
     this.reshapingEdgeRenderer.setEdgeArrowRenderingSupport(
         savedEdgeRenderer.getEdgeArrowRenderingSupport());
 

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/transform/shape/ViewLensSupport.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/transform/shape/ViewLensSupport.java
@@ -48,8 +48,7 @@ public class ViewLensSupport<V, E> extends AbstractLensSupport<V, E> implements 
     lensTransformer.setViewRadius(d.width / 5);
     this.lensGraphicsDecorator = new TransformingFlatnessGraphics(lensTransformer);
     this.savedEdgeRenderer = vv.getRenderer().getEdgeRenderer();
-    this.reshapingEdgeRenderer =
-        new ReshapingEdgeRenderer<V, E>(vv.getGraphLayout(), renderContext);
+    this.reshapingEdgeRenderer = new ReshapingEdgeRenderer<V, E>();
     this.reshapingEdgeRenderer.setEdgeArrowRenderingSupport(
         savedEdgeRenderer.getEdgeArrowRenderingSupport());
   }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/util/LayoutMediator.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/util/LayoutMediator.java
@@ -1,0 +1,25 @@
+package edu.uci.ics.jung.visualization.util;
+
+import com.google.common.graph.Network;
+import edu.uci.ics.jung.algorithms.layout.Layout;
+
+/** Created by Tom Nelson on 9/22/17. */
+public class LayoutMediator<N, E> {
+
+  private final Network<N, E> network;
+
+  private final Layout<N> layout;
+
+  public LayoutMediator(Network<N, E> network, Layout<N> layout) {
+    this.network = network;
+    this.layout = layout;
+  }
+
+  public Network<N, E> getNetwork() {
+    return network;
+  }
+
+  public Layout<N> getLayout() {
+    return layout;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
           <execution>
             <phase>verify</phase>
             <goals>
-              <goal>check</goal>
+              <goal>format</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Makes the Renderers stateless again, introduces a LayoutMediator to send the Network and Layout around to the visualization components. The LayoutMediator  replaces layout.getGraph()