### PR TITLE
This is a fix that will allow the TreeCollapseDemo to work. There is …

### DIFF
--- a/jung-api/src/main/java/edu/uci/ics/jung/graph/DelegateCTreeNetwork.java
+++ b/jung-api/src/main/java/edu/uci/ics/jung/graph/DelegateCTreeNetwork.java
@@ -194,8 +194,7 @@ class DelegateCTreeNetwork<N, E> implements MutableCTreeNetwork<N, E> {
       height = Optional.of(0);
     } else {
       int nodeDepth = depths.get(parent) + 1;
-      height =
-          Optional.of(Math.max(nodeDepth, (height.equals(Optional.empty()) ? 0 : height.get())));
+      height = Optional.of(Math.max(nodeDepth, height.orElse(0)));
       depths.put(node, nodeDepth);
     }
   }

--- a/jung-api/src/main/java/edu/uci/ics/jung/graph/DelegateCTreeNetwork.java
+++ b/jung-api/src/main/java/edu/uci/ics/jung/graph/DelegateCTreeNetwork.java
@@ -194,7 +194,8 @@ class DelegateCTreeNetwork<N, E> implements MutableCTreeNetwork<N, E> {
       height = Optional.of(0);
     } else {
       int nodeDepth = depths.get(parent) + 1;
-      height = Optional.of(Math.max(nodeDepth, height.get()));
+      height =
+          Optional.of(Math.max(nodeDepth, (height.equals(Optional.empty()) ? 0 : height.get())));
       depths.put(node, nodeDepth);
     }
   }

--- a/jung-api/src/test/java/edu/uci/ics/jung/graph/util/TreeUtilsTest.java
+++ b/jung-api/src/test/java/edu/uci/ics/jung/graph/util/TreeUtilsTest.java
@@ -1,0 +1,43 @@
+package edu.uci.ics.jung.graph.util;
+
+import edu.uci.ics.jung.graph.MutableCTreeNetwork;
+import edu.uci.ics.jung.graph.TreeNetworkBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Created by Tom Nelson */
+public class TreeUtilsTest {
+
+  @Test
+  public void testSubTree() {
+
+    MutableCTreeNetwork<String, Integer> tree =
+        TreeNetworkBuilder.builder().expectedNodeCount(7).build();
+
+    tree.addNode("root");
+
+    tree.addEdge("root", "child1", 1); // two kids
+    tree.addEdge("root", "child2", 2);
+
+    tree.addEdge("child1", "grandchild11", 11);
+    tree.addEdge("child1", "grandchild12", 12);
+
+    tree.addEdge("child2", "grandchild21", 21);
+    tree.addEdge("child2", "grandchild22", 22);
+
+    MutableCTreeNetwork<String, Integer> subTree = TreeUtils.getSubTree(tree, "root");
+
+    // better be the same
+    Assert.assertEquals(tree.asGraph(), subTree.asGraph());
+
+    MutableCTreeNetwork<String, Integer> childOneSubTree = TreeUtils.getSubTree(tree, "child1");
+
+    MutableCTreeNetwork<String, Integer> expectedSubTree =
+        TreeNetworkBuilder.builder().expectedNodeCount(3).build();
+    expectedSubTree.addNode("child1");
+    expectedSubTree.addEdge("child1", "grandchild11", 11);
+    expectedSubTree.addEdge("child1", "grandchild12", 12);
+
+    Assert.assertEquals(childOneSubTree.asGraph(), expectedSubTree.asGraph());
+  }
+}


### PR DESCRIPTION
…also a new unit test.

 Changes to be committed:
	modified:   jung-api/src/main/java/edu/uci/ics/jung/graph/DelegateCTreeNetwork.java
	new file:   jung-api/src/test/java/edu/uci/ics/jung/graph/util/TreeUtilsTest.java


The problem was discovered while fixing TreeCollapseDemo. The removeNode method sets height to Optional.empty() but the subsequent addEdge -> setDepth was trying to use the non-existent value in height as a numeric argument to Math.max