### PR TITLE
Addressed edge case in BHQT where a forceElement at the same location…

### DIFF
--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/algorithms/FRBHVisitorLayoutAlgorithm.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/algorithms/FRBHVisitorLayoutAlgorithm.java
@@ -31,12 +31,12 @@ public class FRBHVisitorLayoutAlgorithm<N> extends FRLayoutAlgorithm<N>
   @Override
   public void visit(LayoutModel<N> layoutModel) {
     super.visit(layoutModel);
-    tree = new BarnesHutQuadTree(layoutModel);
+    tree = new BarnesHutQuadTree(layoutModel.getWidth(), layoutModel.getHeight());
   }
 
   @Override
   public synchronized void step() {
-    tree.rebuild();
+    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
     super.step();
   }
 

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/algorithms/FRBHVisitorLayoutAlgorithm.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/algorithms/FRBHVisitorLayoutAlgorithm.java
@@ -36,7 +36,7 @@ public class FRBHVisitorLayoutAlgorithm<N> extends FRLayoutAlgorithm<N>
 
   @Override
   public synchronized void step() {
-    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
+    tree.rebuild(layoutModel);
     super.step();
   }
 

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/algorithms/SpringBHVisitorLayoutAlgorithm.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/algorithms/SpringBHVisitorLayoutAlgorithm.java
@@ -42,12 +42,12 @@ public class SpringBHVisitorLayoutAlgorithm<N> extends SpringLayoutAlgorithm<N>
   @Override
   public void visit(LayoutModel<N> layoutModel) {
     super.visit(layoutModel);
-    tree = new BarnesHutQuadTree(layoutModel);
+    tree = new BarnesHutQuadTree(layoutModel.getWidth(), layoutModel.getHeight());
   }
 
   @Override
   public void step() {
-    tree.rebuild();
+    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
     super.step();
   }
 

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/algorithms/SpringBHVisitorLayoutAlgorithm.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/algorithms/SpringBHVisitorLayoutAlgorithm.java
@@ -47,7 +47,7 @@ public class SpringBHVisitorLayoutAlgorithm<N> extends SpringLayoutAlgorithm<N>
 
   @Override
   public void step() {
-    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
+    tree.rebuild(layoutModel);
     super.step();
   }
 

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/spatial/BarnesHutQuadTree.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/spatial/BarnesHutQuadTree.java
@@ -1,6 +1,7 @@
 package edu.uci.ics.jung.layout.spatial;
 
 import com.google.common.collect.Sets;
+import edu.uci.ics.jung.layout.model.LayoutModel;
 import edu.uci.ics.jung.layout.model.Point;
 import java.util.Collection;
 import java.util.Collections;
@@ -117,6 +118,10 @@ public class BarnesHutQuadTree<T> {
         insert(forceObject);
       }
     }
+  }
+
+  public void rebuild(LayoutModel<T> layoutModel) {
+    rebuild(layoutModel.getGraph().nodes(), layoutModel);
   }
 
   @Override

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/spatial/BarnesHutQuadTree.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/spatial/BarnesHutQuadTree.java
@@ -1,11 +1,12 @@
 package edu.uci.ics.jung.layout.spatial;
 
 import com.google.common.collect.Sets;
-import edu.uci.ics.jung.layout.model.LayoutModel;
 import edu.uci.ics.jung.layout.model.Point;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,14 +32,14 @@ public class BarnesHutQuadTree<T> {
     return root;
   }
 
-  protected LayoutModel<T> layoutModel;
-
   private Object lock = new Object();
 
-  /** @param layoutModel */
-  public BarnesHutQuadTree(LayoutModel<T> layoutModel) {
-    this.layoutModel = layoutModel;
-    this.root = new Node(new Rectangle(0, 0, layoutModel.getWidth(), layoutModel.getHeight()));
+  public BarnesHutQuadTree(double width, double height) {
+    this.root = new Node(new Rectangle(0, 0, width, height));
+  }
+
+  public BarnesHutQuadTree(Rectangle r) {
+    this.root = new Node(r);
   }
 
   /*
@@ -107,11 +108,11 @@ public class BarnesHutQuadTree<T> {
     }
   }
 
-  public void rebuild() {
+  public void rebuild(Collection<T> nodes, Function<T, Point> function) {
     clear();
     synchronized (lock) {
-      for (T node : layoutModel.getGraph().nodes()) {
-        Point p = layoutModel.apply(node);
+      for (T node : nodes) {
+        Point p = function.apply(node);
         ForceObject<T> forceObject = new ForceObject<T>(node, p);
         insert(forceObject);
       }

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/spatial/BarnesHutQuadTree.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/spatial/BarnesHutQuadTree.java
@@ -109,7 +109,13 @@ public class BarnesHutQuadTree<T> {
     }
   }
 
-  public void rebuild(Collection<T> nodes, Function<T, Point> function) {
+  /**
+   * package level for unit test use
+   *
+   * @param nodes
+   * @param function
+   */
+  void rebuild(Collection<T> nodes, Function<T, Point> function) {
     clear();
     synchronized (lock) {
       for (T node : nodes) {

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/spatial/Node.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/spatial/Node.java
@@ -85,7 +85,7 @@ public class Node<T> {
       } else {
         // there already is a forceObject and location is different, so split
         split();
-        // put the current resident and the new one into the correct quardrants
+        // put the current resident and the new one into the correct quadrants
         insertForceObject(this.forceObject);
         insertForceObject(element);
         // update the centerOfMass, Mass, and Force on this node

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/spatial/Node.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/layout/spatial/Node.java
@@ -24,7 +24,7 @@ public class Node<T> {
   Node SE;
   Node SW;
 
-  private Rectangle area;
+  protected Rectangle area;
 
   public Node(double x, double y, double width, double height) {
     this(new Rectangle(x, y, width, height));
@@ -77,14 +77,20 @@ public class Node<T> {
       return;
     }
     if (isLeaf()) {
-      // there already is a forceObject, so split
-      split();
-      // put the current resident and the new one into the correct quardrants
-      insertForceObject(this.forceObject);
-      insertForceObject(element);
-      // update the centerOfMass, Mass, and Force on this node
-      this.forceObject = this.forceObject.add(element);
-
+      if (this.forceObject.p.equals(element.p)) {
+        // compare points for special case where the 2 elements are at the same location
+        // this would cause an infinite attempt to split and re-insert
+        // just add the new mass
+        this.forceObject = this.forceObject.add(element);
+      } else {
+        // there already is a forceObject and location is different, so split
+        split();
+        // put the current resident and the new one into the correct quardrants
+        insertForceObject(this.forceObject);
+        insertForceObject(element);
+        // update the centerOfMass, Mass, and Force on this node
+        this.forceObject = this.forceObject.add(element);
+      }
     } else {
       if (forceObject == element) {
         log.error("can't insert {} into {}", element, this.forceObject);
@@ -217,10 +223,11 @@ public class Node<T> {
     return "[" + (int) r.x + "," + (int) r.y + "," + (int) r.width + "," + (int) r.height + "]";
   }
 
-  static <T> String asString(Node<T> node, String margin) {
+  static <T> String asString(String label, Node<T> node, String margin) {
     StringBuilder s = new StringBuilder();
     s.append("\n");
     s.append(margin);
+    s.append(label);
     s.append("bounds=");
     s.append(asString(node.getBounds()));
     ForceObject forceObject = node.getForceObject();
@@ -228,10 +235,10 @@ public class Node<T> {
       s.append(", forceObject:=");
       s.append(forceObject.toString());
     }
-    if (node.NW != null) s.append(asString(node.NW, margin + marginIncrement));
-    if (node.NE != null) s.append(asString(node.NE, margin + marginIncrement));
-    if (node.SW != null) s.append(asString(node.SW, margin + marginIncrement));
-    if (node.SE != null) s.append(asString(node.SE, margin + marginIncrement));
+    if (node.NW != null) s.append(asString("NW:", node.NW, margin + marginIncrement));
+    if (node.NE != null) s.append(asString("NE:", node.NE, margin + marginIncrement));
+    if (node.SW != null) s.append(asString("SW:", node.SW, margin + marginIncrement));
+    if (node.SE != null) s.append(asString("SE:", node.SE, margin + marginIncrement));
 
     return s.toString();
   }
@@ -240,6 +247,6 @@ public class Node<T> {
 
   @Override
   public String toString() {
-    return asString(this, "");
+    return asString("", this, "");
   }
 }

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/algorithms/FRBHIteratorLayoutAlgorithm.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/algorithms/FRBHIteratorLayoutAlgorithm.java
@@ -40,7 +40,7 @@ public class FRBHIteratorLayoutAlgorithm<N> extends FRLayoutAlgorithm<N>
 
   @Override
   public synchronized void step() {
-    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
+    tree.rebuild(layoutModel);
     super.step();
   }
 

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/algorithms/FRBHIteratorLayoutAlgorithm.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/algorithms/FRBHIteratorLayoutAlgorithm.java
@@ -35,12 +35,12 @@ public class FRBHIteratorLayoutAlgorithm<N> extends FRLayoutAlgorithm<N>
   @Override
   public void visit(LayoutModel<N> layoutModel) {
     super.visit(layoutModel);
-    tree = new BarnesHutQuadTree(layoutModel);
+    tree = new BarnesHutQuadTree(layoutModel.getWidth(), layoutModel.getHeight());
   }
 
   @Override
   public synchronized void step() {
-    tree.rebuild();
+    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
     super.step();
   }
 

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/algorithms/SpringBHIteratorLayoutAlgorithm.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/algorithms/SpringBHIteratorLayoutAlgorithm.java
@@ -50,7 +50,7 @@ public class SpringBHIteratorLayoutAlgorithm<N> extends SpringLayoutAlgorithm<N>
 
   @Override
   public void step() {
-    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
+    tree.rebuild(layoutModel);
     super.step();
   }
 

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/algorithms/SpringBHIteratorLayoutAlgorithm.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/algorithms/SpringBHIteratorLayoutAlgorithm.java
@@ -45,12 +45,12 @@ public class SpringBHIteratorLayoutAlgorithm<N> extends SpringLayoutAlgorithm<N>
   @Override
   public void visit(LayoutModel<N> layoutModel) {
     super.visit(layoutModel);
-    tree = new BarnesHutQuadTree(layoutModel);
+    tree = new BarnesHutQuadTree(layoutModel.getWidth(), layoutModel.getHeight());
   }
 
   @Override
   public void step() {
-    tree.rebuild();
+    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
     super.step();
   }
 

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/spatial/BarnesHutQuadTreeTests.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/spatial/BarnesHutQuadTreeTests.java
@@ -58,7 +58,6 @@ public class BarnesHutQuadTreeTests {
     Node<String> root = tree.getRoot();
     Assert.assertTrue(root.isLeaf() == false);
     Node<String> NW = root.NW;
-    Point q = forceObjectA.add(forceObjectB).add(forceObjectC).p;
     Assert.assertTrue(NW.forceObject.equals(forceObjectA.add(forceObjectB).add(forceObjectC)));
     Assert.assertTrue(NW.isLeaf() == false);
     Assert.assertTrue(NW.NW.forceObject.equals(forceObjectC));

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/spatial/BarnesHutQuadTreeTests.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/spatial/BarnesHutQuadTreeTests.java
@@ -1,0 +1,70 @@
+package edu.uci.ics.jung.layout.spatial;
+
+import edu.uci.ics.jung.layout.model.Point;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test of basic construction of the BarnesHutQuadTree, including an edge case with forceObjects at
+ * the same location
+ *
+ * @author Tom Nelson
+ */
+public class BarnesHutQuadTreeTests {
+
+  private static final Logger log = LoggerFactory.getLogger(BarnesHutQuadTreeTests.class);
+  private BarnesHutQuadTree<String> tree;
+
+  @Before
+  public void setup() {
+    tree = new BarnesHutQuadTree<>(500, 500);
+  }
+
+  /**
+   * test that edge case where all force objects are at the same location results in the correct
+   * tree
+   */
+  @Test
+  public void testOne() {
+    ForceObject<String> forceObjectOne = new ForceObject("A", Point.of(10, 10));
+    ForceObject<String> forceObjectTwo = new ForceObject("B", Point.of(10, 10));
+    ForceObject<String> forceObjectThree = new ForceObject("C", Point.of(10, 10));
+    tree.insert(forceObjectOne);
+    tree.insert(forceObjectTwo);
+    tree.insert(forceObjectThree);
+
+    log.info("tree: {}", tree);
+    ForceObject<String> expectedForceObject = new ForceObject("force", Point.of(10, 10), 3);
+    Assert.assertTrue(tree.getRoot().forceObject.equals(expectedForceObject));
+  }
+
+  /** test a simple construction */
+  @Test
+  public void testTwo() {
+    ForceObject<String> forceObjectA = new ForceObject<>("A", Point.of(200, 100));
+    ForceObject<String> forceObjectB = new ForceObject<>("B", Point.of(100, 200));
+    ForceObject<String> forceObjectC = new ForceObject<>("C", Point.of(100, 100));
+    ForceObject<String> forceObjectD = new ForceObject<>("D", Point.of(500, 100));
+    tree.insert(forceObjectA);
+    tree.insert(forceObjectB);
+    tree.insert(forceObjectC);
+    tree.insert(forceObjectD);
+
+    log.info("tree: {}", tree);
+    Assert.assertTrue(tree.getRoot() != null);
+    Node<String> root = tree.getRoot();
+    Assert.assertTrue(root.isLeaf() == false);
+    Node<String> NW = root.NW;
+    Point q = forceObjectA.add(forceObjectB).add(forceObjectC).p;
+    Assert.assertTrue(NW.forceObject.equals(forceObjectA.add(forceObjectB).add(forceObjectC)));
+    Assert.assertTrue(NW.isLeaf() == false);
+    Assert.assertTrue(NW.NW.forceObject.equals(forceObjectC));
+    Assert.assertTrue(NW.NE.forceObject.equals(forceObjectA));
+    Assert.assertTrue(NW.SW.forceObject.equals(forceObjectB));
+    Assert.assertTrue(NW.SE.forceObject == null);
+    Assert.assertTrue(root.NE.forceObject.equals(forceObjectD));
+  }
+}

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/BarnesHutVisualizer.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/BarnesHutVisualizer.java
@@ -70,8 +70,8 @@ public class BarnesHutVisualizer extends JPanel {
     layoutModel.set("C", Point.of(100, 100));
     layoutModel.set("D", Point.of(500, 100));
 
-    tree = new BarnesHutQuadTree<>(layoutModel);
-    tree.rebuild();
+    tree = new BarnesHutQuadTree<>(layoutModel.getWidth(), layoutModel.getHeight());
+    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
 
     JPanel drawingPanel =
         new JPanel() {
@@ -145,7 +145,7 @@ public class BarnesHutVisualizer extends JPanel {
       network.removeNode(node);
     }
     tree.clear();
-    tree.rebuild();
+    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
     repaint();
   }
 
@@ -153,7 +153,7 @@ public class BarnesHutVisualizer extends JPanel {
     String n = "N" + network.nodes().size();
     layoutModel.set(n, p.getX(), p.getY());
     network.addNode(n);
-    tree.rebuild();
+    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
     repaint();
   }
 

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/BarnesHutVisualizer.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/BarnesHutVisualizer.java
@@ -71,7 +71,7 @@ public class BarnesHutVisualizer extends JPanel {
     layoutModel.set("D", Point.of(500, 100));
 
     tree = new BarnesHutQuadTree<>(layoutModel.getWidth(), layoutModel.getHeight());
-    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
+    tree.rebuild(layoutModel);
 
     JPanel drawingPanel =
         new JPanel() {
@@ -145,7 +145,7 @@ public class BarnesHutVisualizer extends JPanel {
       network.removeNode(node);
     }
     tree.clear();
-    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
+    tree.rebuild(layoutModel);
     repaint();
   }
 
@@ -153,7 +153,7 @@ public class BarnesHutVisualizer extends JPanel {
     String n = "N" + network.nodes().size();
     layoutModel.set(n, p.getX(), p.getY());
     network.addNode(n);
-    tree.rebuild(layoutModel.getGraph().nodes(), layoutModel);
+    tree.rebuild(layoutModel);
     repaint();
   }
 


### PR DESCRIPTION
… will start an infinite recursion.

This happens when a LayoutModel initializer starts with all points at the same location, as when the
LayoutModel initializer has all points at the origin. This change has the BHQT just sum the masses in that case.
Also made the BHQD not dependent on the LayoutModel instance as part of its state.
Added unit tests for BHQT

 Changes to be committed:
	modified:   jung-algorithms/src/main/java/edu/uci/ics/jung/layout/algorithms/FRBHVisitorLayoutAlgorithm.java
	modified:   jung-algorithms/src/main/java/edu/uci/ics/jung/layout/algorithms/SpringBHVisitorLayoutAlgorithm.java
	modified:   jung-algorithms/src/main/java/edu/uci/ics/jung/layout/spatial/BarnesHutQuadTree.java
	modified:   jung-algorithms/src/main/java/edu/uci/ics/jung/layout/spatial/Node.java
	modified:   jung-algorithms/src/test/java/edu/uci/ics/jung/layout/algorithms/FRBHIteratorLayoutAlgorithm.java
	modified:   jung-algorithms/src/test/java/edu/uci/ics/jung/layout/algorithms/SpringBHIteratorLayoutAlgorithm.java
	new file:   jung-algorithms/src/test/java/edu/uci/ics/jung/layout/spatial/BarnesHutQuadTreeTests.java
	modified:   jung-samples/src/main/java/edu/uci/ics/jung/samples/BarnesHutVisualizer.java