### PR TITLE
Extensions to Truth library: PointSubject and Rectangle2DSubject

### DIFF
--- a/jung-algorithms/pom.xml
+++ b/jung-algorithms/pom.xml
@@ -32,6 +32,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>0.39</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>net.sf.jung</groupId>
       <artifactId>jung-api</artifactId>
       <version>${project.version}</version>

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/truth/PointSubject.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/truth/PointSubject.java
@@ -1,84 +1,90 @@
 package edu.uci.ics.jung.layout.truth;
 
+import static com.google.common.truth.Truth.assertAbout;
+
 import com.google.common.base.Preconditions;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.MathUtil;
 import com.google.common.truth.Subject;
 import edu.uci.ics.jung.layout.model.Point;
-
 import javax.annotation.Nullable;
 
-import static com.google.common.truth.Truth.assertAbout;
-
 public class PointSubject extends Subject<PointSubject, Point> {
-    private static final long NEG_ZERO_BITS = Double.doubleToLongBits(-0.0D);
+  private static final long NEG_ZERO_BITS = Double.doubleToLongBits(-0.0D);
 
-    PointSubject(FailureMetadata metadata, @Nullable Point actual) {
-        super(metadata, actual);
-    }
+  PointSubject(FailureMetadata metadata, @Nullable Point actual) {
+    super(metadata, actual);
+  }
 
-    public static Subject.Factory<PointSubject, Point> points() {
-        return PointSubject::new;
-    }
+  public static Subject.Factory<PointSubject, Point> points() {
+    return PointSubject::new;
+  }
 
-    public static PointSubject assertThat(@Nullable Point actual) {
-        return assertAbout(points()).that(actual);
-    }
+  public static PointSubject assertThat(@Nullable Point actual) {
+    return assertAbout(points()).that(actual);
+  }
 
-    static void checkTolerance(double tolerance) {
-        Preconditions.checkArgument(!Double.isNaN(tolerance), "tolerance cannot be NaN");
-        Preconditions.checkArgument(tolerance >= 0.0D, "tolerance (%s) cannot be negative", tolerance);
-        Preconditions.checkArgument(Double.doubleToLongBits(tolerance) != NEG_ZERO_BITS, "tolerance (%s) cannot be negative", tolerance);
-        Preconditions.checkArgument(tolerance != 1.0D / 0.0, "tolerance cannot be POSITIVE_INFINITY");
-    }
+  static void checkTolerance(double tolerance) {
+    Preconditions.checkArgument(!Double.isNaN(tolerance), "tolerance cannot be NaN");
+    Preconditions.checkArgument(tolerance >= 0.0D, "tolerance (%s) cannot be negative", tolerance);
+    Preconditions.checkArgument(
+        Double.doubleToLongBits(tolerance) != NEG_ZERO_BITS,
+        "tolerance (%s) cannot be negative",
+        tolerance);
+    Preconditions.checkArgument(tolerance != 1.0D / 0.0, "tolerance cannot be POSITIVE_INFINITY");
+  }
 
-    public PointSubject.TolerantPointComparison isWithin(double tolerance) {
+  public PointSubject.TolerantPointComparison isWithin(double tolerance) {
 
-        return new PointSubject.TolerantPointComparison() {
-            public void of(Point expected) {
-                Point actual = (Point)PointSubject.this.actual();
-                Preconditions.checkNotNull(actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
-                PointSubject.checkTolerance(tolerance);
-                if (!MathUtil.equalWithinTolerance(actual.x, expected.x, tolerance) || !MathUtil.equalWithinTolerance(actual.y, expected.y, tolerance)) {
-                    PointSubject.this.failWithRawMessage("%s and <%s> should have been finite values not within <%s> of each other",
-                            new Object[]{PointSubject.this.actualAsString(), expected, tolerance});
-                }
-
-            }
-        };
-    }
-
-    public PointSubject.TolerantPointComparison isNotWithin(final double tolerance) {
-        return new PointSubject.TolerantPointComparison() {
-            public void of(Point expected) {
-                Point actual = (Point)PointSubject.this.actual();
-                Preconditions.checkNotNull(actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
-                PointSubject.checkTolerance(tolerance);
-                if (!MathUtil.notEqualWithinTolerance(actual.x, expected.x, tolerance)  && !MathUtil.notEqualWithinTolerance(actual.y, expected.y, tolerance)) {
-                    PointSubject.this.failWithRawMessage("%s and <%s> should have been finite values not within <%s> of each other", new Object[]{PointSubject.this.actualAsString(), expected, tolerance});
-                }
-
-            }
-        };
-    }
-
-    public abstract static class TolerantPointComparison {
-        private TolerantPointComparison() {
+    return new PointSubject.TolerantPointComparison() {
+      public void of(Point expected) {
+        Point actual = (Point) PointSubject.this.actual();
+        Preconditions.checkNotNull(
+            actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
+        PointSubject.checkTolerance(tolerance);
+        if (!MathUtil.equalWithinTolerance(actual.x, expected.x, tolerance)
+            || !MathUtil.equalWithinTolerance(actual.y, expected.y, tolerance)) {
+          PointSubject.this.failWithRawMessage(
+              "%s and <%s> should have been finite values not within <%s> of each other",
+              new Object[] {PointSubject.this.actualAsString(), expected, tolerance});
         }
+      }
+    };
+  }
 
-        public abstract void of(Point var1);
-
-        /** @deprecated */
-        @Deprecated
-        public boolean equals(@Nullable Object o) {
-            throw new UnsupportedOperationException("If you meant to compare doubles, use .of(double) instead.");
+  public PointSubject.TolerantPointComparison isNotWithin(final double tolerance) {
+    return new PointSubject.TolerantPointComparison() {
+      public void of(Point expected) {
+        Point actual = (Point) PointSubject.this.actual();
+        Preconditions.checkNotNull(
+            actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
+        PointSubject.checkTolerance(tolerance);
+        if (!MathUtil.notEqualWithinTolerance(actual.x, expected.x, tolerance)
+            && !MathUtil.notEqualWithinTolerance(actual.y, expected.y, tolerance)) {
+          PointSubject.this.failWithRawMessage(
+              "%s and <%s> should have been finite values not within <%s> of each other",
+              new Object[] {PointSubject.this.actualAsString(), expected, tolerance});
         }
+      }
+    };
+  }
 
-        /** @deprecated */
-        @Deprecated
-        public int hashCode() {
-            throw new UnsupportedOperationException("Subject.hashCode() is not supported.");
-        }
+  public abstract static class TolerantPointComparison {
+    private TolerantPointComparison() {}
+
+    public abstract void of(Point var1);
+
+    /** @deprecated */
+    @Deprecated
+    public boolean equals(@Nullable Object o) {
+      throw new UnsupportedOperationException(
+          "If you meant to compare doubles, use .of(double) instead.");
     }
 
+    /** @deprecated */
+    @Deprecated
+    public int hashCode() {
+      throw new UnsupportedOperationException("Subject.hashCode() is not supported.");
+    }
+  }
 }

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/truth/PointSubject.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/truth/PointSubject.java
@@ -1,0 +1,84 @@
+package edu.uci.ics.jung.layout.truth;
+
+import com.google.common.base.Preconditions;
+import com.google.common.truth.FailureMetadata;
+import com.google.common.truth.MathUtil;
+import com.google.common.truth.Subject;
+import edu.uci.ics.jung.layout.model.Point;
+
+import javax.annotation.Nullable;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+public class PointSubject extends Subject<PointSubject, Point> {
+    private static final long NEG_ZERO_BITS = Double.doubleToLongBits(-0.0D);
+
+    PointSubject(FailureMetadata metadata, @Nullable Point actual) {
+        super(metadata, actual);
+    }
+
+    public static Subject.Factory<PointSubject, Point> points() {
+        return PointSubject::new;
+    }
+
+    public static PointSubject assertThat(@Nullable Point actual) {
+        return assertAbout(points()).that(actual);
+    }
+
+    static void checkTolerance(double tolerance) {
+        Preconditions.checkArgument(!Double.isNaN(tolerance), "tolerance cannot be NaN");
+        Preconditions.checkArgument(tolerance >= 0.0D, "tolerance (%s) cannot be negative", tolerance);
+        Preconditions.checkArgument(Double.doubleToLongBits(tolerance) != NEG_ZERO_BITS, "tolerance (%s) cannot be negative", tolerance);
+        Preconditions.checkArgument(tolerance != 1.0D / 0.0, "tolerance cannot be POSITIVE_INFINITY");
+    }
+
+    public PointSubject.TolerantPointComparison isWithin(double tolerance) {
+
+        return new PointSubject.TolerantPointComparison() {
+            public void of(Point expected) {
+                Point actual = (Point)PointSubject.this.actual();
+                Preconditions.checkNotNull(actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
+                PointSubject.checkTolerance(tolerance);
+                if (!MathUtil.equalWithinTolerance(actual.x, expected.x, tolerance) || !MathUtil.equalWithinTolerance(actual.y, expected.y, tolerance)) {
+                    PointSubject.this.failWithRawMessage("%s and <%s> should have been finite values not within <%s> of each other",
+                            new Object[]{PointSubject.this.actualAsString(), expected, tolerance});
+                }
+
+            }
+        };
+    }
+
+    public PointSubject.TolerantPointComparison isNotWithin(final double tolerance) {
+        return new PointSubject.TolerantPointComparison() {
+            public void of(Point expected) {
+                Point actual = (Point)PointSubject.this.actual();
+                Preconditions.checkNotNull(actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
+                PointSubject.checkTolerance(tolerance);
+                if (!MathUtil.notEqualWithinTolerance(actual.x, expected.x, tolerance)  && !MathUtil.notEqualWithinTolerance(actual.y, expected.y, tolerance)) {
+                    PointSubject.this.failWithRawMessage("%s and <%s> should have been finite values not within <%s> of each other", new Object[]{PointSubject.this.actualAsString(), expected, tolerance});
+                }
+
+            }
+        };
+    }
+
+    public abstract static class TolerantPointComparison {
+        private TolerantPointComparison() {
+        }
+
+        public abstract void of(Point var1);
+
+        /** @deprecated */
+        @Deprecated
+        public boolean equals(@Nullable Object o) {
+            throw new UnsupportedOperationException("If you meant to compare doubles, use .of(double) instead.");
+        }
+
+        /** @deprecated */
+        @Deprecated
+        public int hashCode() {
+            throw new UnsupportedOperationException("Subject.hashCode() is not supported.");
+        }
+    }
+
+}

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/truth/Rectangle2DSubject.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/truth/Rectangle2DSubject.java
@@ -1,0 +1,92 @@
+package edu.uci.ics.jung.layout.truth;
+
+import com.google.common.base.Preconditions;
+import com.google.common.truth.FailureMetadata;
+import com.google.common.truth.MathUtil;
+import com.google.common.truth.Subject;
+
+import javax.annotation.Nullable;
+import java.awt.geom.Rectangle2D;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+public class Rectangle2DSubject extends Subject<Rectangle2DSubject, Rectangle2D> {
+    private static final long NEG_ZERO_BITS = Double.doubleToLongBits(-0.0D);
+
+    Rectangle2DSubject(FailureMetadata metadata, @Nullable Rectangle2D actual) {
+        super(metadata, actual);
+    }
+
+    public static Factory<Rectangle2DSubject, Rectangle2D> rectangles() {
+        return Rectangle2DSubject::new;
+    }
+
+    public static Rectangle2DSubject assertThat(@Nullable Rectangle2D actual) {
+        return assertAbout(rectangles()).that(actual);
+    }
+
+    static void checkTolerance(double tolerance) {
+        Preconditions.checkArgument(!Double.isNaN(tolerance), "tolerance cannot be NaN");
+        Preconditions.checkArgument(tolerance >= 0.0D, "tolerance (%s) cannot be negative", tolerance);
+        Preconditions.checkArgument(Double.doubleToLongBits(tolerance) != NEG_ZERO_BITS, "tolerance (%s) cannot be negative", tolerance);
+        Preconditions.checkArgument(tolerance != 1.0D / 0.0, "tolerance cannot be POSITIVE_INFINITY");
+    }
+
+    public Rectangle2DSubject.TolerantRectangle2DComparison isWithin(double tolerance) {
+
+        return new Rectangle2DSubject.TolerantRectangle2DComparison() {
+            public void of(Rectangle2D expected) {
+                Rectangle2D actual = (Rectangle2D)Rectangle2DSubject.this.actual();
+                Preconditions.checkNotNull(actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
+                Rectangle2DSubject.checkTolerance(tolerance);
+                if (!MathUtil.equalWithinTolerance(actual.getMinX(), expected.getMinX(), tolerance) ||
+                        !MathUtil.equalWithinTolerance(actual.getMinY(), expected.getMinY(), tolerance) ||
+                        !MathUtil.equalWithinTolerance(actual.getMaxX(), expected.getMaxX(), tolerance) ||
+                        !MathUtil.equalWithinTolerance(actual.getMaxY(), expected.getMaxY(), tolerance)
+                        ) {
+                    Rectangle2DSubject.this.failWithRawMessage("%s and <%s> should have been finite values not within <%s> of each other",
+                            new Object[]{Rectangle2DSubject.this.actualAsString(), expected, tolerance});
+                }
+
+            }
+        };
+    }
+
+    public Rectangle2DSubject.TolerantRectangle2DComparison isNotWithin(final double tolerance) {
+        return new Rectangle2DSubject.TolerantRectangle2DComparison() {
+            public void of(Rectangle2D expected) {
+                Rectangle2D actual = (Rectangle2D)Rectangle2DSubject.this.actual();
+                Preconditions.checkNotNull(actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
+                Rectangle2DSubject.checkTolerance(tolerance);
+                if (!MathUtil.notEqualWithinTolerance(actual.getMinX(), expected.getMinX(), tolerance)  &&
+                        !MathUtil.notEqualWithinTolerance(actual.getMinY(), expected.getMinY(), tolerance) &&
+                        !MathUtil.notEqualWithinTolerance(actual.getMaxX(), expected.getMaxX(), tolerance) &&
+                        !MathUtil.notEqualWithinTolerance(actual.getMaxY(), expected.getMaxY(), tolerance)
+                        ) {
+                    Rectangle2DSubject.this.failWithRawMessage("%s and <%s> should have been finite values not within <%s> of each other", new Object[]{Rectangle2DSubject.this.actualAsString(), expected, tolerance});
+                }
+
+            }
+        };
+    }
+
+    public abstract static class TolerantRectangle2DComparison {
+        private TolerantRectangle2DComparison() {
+        }
+
+        public abstract void of(Rectangle2D var1);
+
+        /** @deprecated */
+        @Deprecated
+        public boolean equals(@Nullable Object o) {
+            throw new UnsupportedOperationException("If you meant to compare rectangles, use .of(rectangle) instead.");
+        }
+
+        /** @deprecated */
+        @Deprecated
+        public int hashCode() {
+            throw new UnsupportedOperationException("Subject.hashCode() is not supported.");
+        }
+    }
+
+}

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/truth/Rectangle2DSubject.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/truth/Rectangle2DSubject.java
@@ -1,92 +1,94 @@
 package edu.uci.ics.jung.layout.truth;
 
+import static com.google.common.truth.Truth.assertAbout;
+
 import com.google.common.base.Preconditions;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.MathUtil;
 import com.google.common.truth.Subject;
-
-import javax.annotation.Nullable;
 import java.awt.geom.Rectangle2D;
-
-import static com.google.common.truth.Truth.assertAbout;
+import javax.annotation.Nullable;
 
 public class Rectangle2DSubject extends Subject<Rectangle2DSubject, Rectangle2D> {
-    private static final long NEG_ZERO_BITS = Double.doubleToLongBits(-0.0D);
+  private static final long NEG_ZERO_BITS = Double.doubleToLongBits(-0.0D);
 
-    Rectangle2DSubject(FailureMetadata metadata, @Nullable Rectangle2D actual) {
-        super(metadata, actual);
-    }
+  Rectangle2DSubject(FailureMetadata metadata, @Nullable Rectangle2D actual) {
+    super(metadata, actual);
+  }
 
-    public static Factory<Rectangle2DSubject, Rectangle2D> rectangles() {
-        return Rectangle2DSubject::new;
-    }
+  public static Factory<Rectangle2DSubject, Rectangle2D> rectangles() {
+    return Rectangle2DSubject::new;
+  }
 
-    public static Rectangle2DSubject assertThat(@Nullable Rectangle2D actual) {
-        return assertAbout(rectangles()).that(actual);
-    }
+  public static Rectangle2DSubject assertThat(@Nullable Rectangle2D actual) {
+    return assertAbout(rectangles()).that(actual);
+  }
 
-    static void checkTolerance(double tolerance) {
-        Preconditions.checkArgument(!Double.isNaN(tolerance), "tolerance cannot be NaN");
-        Preconditions.checkArgument(tolerance >= 0.0D, "tolerance (%s) cannot be negative", tolerance);
-        Preconditions.checkArgument(Double.doubleToLongBits(tolerance) != NEG_ZERO_BITS, "tolerance (%s) cannot be negative", tolerance);
-        Preconditions.checkArgument(tolerance != 1.0D / 0.0, "tolerance cannot be POSITIVE_INFINITY");
-    }
+  static void checkTolerance(double tolerance) {
+    Preconditions.checkArgument(!Double.isNaN(tolerance), "tolerance cannot be NaN");
+    Preconditions.checkArgument(tolerance >= 0.0D, "tolerance (%s) cannot be negative", tolerance);
+    Preconditions.checkArgument(
+        Double.doubleToLongBits(tolerance) != NEG_ZERO_BITS,
+        "tolerance (%s) cannot be negative",
+        tolerance);
+    Preconditions.checkArgument(tolerance != 1.0D / 0.0, "tolerance cannot be POSITIVE_INFINITY");
+  }
 
-    public Rectangle2DSubject.TolerantRectangle2DComparison isWithin(double tolerance) {
+  public Rectangle2DSubject.TolerantRectangle2DComparison isWithin(double tolerance) {
 
-        return new Rectangle2DSubject.TolerantRectangle2DComparison() {
-            public void of(Rectangle2D expected) {
-                Rectangle2D actual = (Rectangle2D)Rectangle2DSubject.this.actual();
-                Preconditions.checkNotNull(actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
-                Rectangle2DSubject.checkTolerance(tolerance);
-                if (!MathUtil.equalWithinTolerance(actual.getMinX(), expected.getMinX(), tolerance) ||
-                        !MathUtil.equalWithinTolerance(actual.getMinY(), expected.getMinY(), tolerance) ||
-                        !MathUtil.equalWithinTolerance(actual.getMaxX(), expected.getMaxX(), tolerance) ||
-                        !MathUtil.equalWithinTolerance(actual.getMaxY(), expected.getMaxY(), tolerance)
-                        ) {
-                    Rectangle2DSubject.this.failWithRawMessage("%s and <%s> should have been finite values not within <%s> of each other",
-                            new Object[]{Rectangle2DSubject.this.actualAsString(), expected, tolerance});
-                }
-
-            }
-        };
-    }
-
-    public Rectangle2DSubject.TolerantRectangle2DComparison isNotWithin(final double tolerance) {
-        return new Rectangle2DSubject.TolerantRectangle2DComparison() {
-            public void of(Rectangle2D expected) {
-                Rectangle2D actual = (Rectangle2D)Rectangle2DSubject.this.actual();
-                Preconditions.checkNotNull(actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
-                Rectangle2DSubject.checkTolerance(tolerance);
-                if (!MathUtil.notEqualWithinTolerance(actual.getMinX(), expected.getMinX(), tolerance)  &&
-                        !MathUtil.notEqualWithinTolerance(actual.getMinY(), expected.getMinY(), tolerance) &&
-                        !MathUtil.notEqualWithinTolerance(actual.getMaxX(), expected.getMaxX(), tolerance) &&
-                        !MathUtil.notEqualWithinTolerance(actual.getMaxY(), expected.getMaxY(), tolerance)
-                        ) {
-                    Rectangle2DSubject.this.failWithRawMessage("%s and <%s> should have been finite values not within <%s> of each other", new Object[]{Rectangle2DSubject.this.actualAsString(), expected, tolerance});
-                }
-
-            }
-        };
-    }
-
-    public abstract static class TolerantRectangle2DComparison {
-        private TolerantRectangle2DComparison() {
+    return new Rectangle2DSubject.TolerantRectangle2DComparison() {
+      public void of(Rectangle2D expected) {
+        Rectangle2D actual = (Rectangle2D) Rectangle2DSubject.this.actual();
+        Preconditions.checkNotNull(
+            actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
+        Rectangle2DSubject.checkTolerance(tolerance);
+        if (!MathUtil.equalWithinTolerance(actual.getMinX(), expected.getMinX(), tolerance)
+            || !MathUtil.equalWithinTolerance(actual.getMinY(), expected.getMinY(), tolerance)
+            || !MathUtil.equalWithinTolerance(actual.getMaxX(), expected.getMaxX(), tolerance)
+            || !MathUtil.equalWithinTolerance(actual.getMaxY(), expected.getMaxY(), tolerance)) {
+          Rectangle2DSubject.this.failWithRawMessage(
+              "%s and <%s> should have been finite values not within <%s> of each other",
+              new Object[] {Rectangle2DSubject.this.actualAsString(), expected, tolerance});
         }
+      }
+    };
+  }
 
-        public abstract void of(Rectangle2D var1);
-
-        /** @deprecated */
-        @Deprecated
-        public boolean equals(@Nullable Object o) {
-            throw new UnsupportedOperationException("If you meant to compare rectangles, use .of(rectangle) instead.");
+  public Rectangle2DSubject.TolerantRectangle2DComparison isNotWithin(final double tolerance) {
+    return new Rectangle2DSubject.TolerantRectangle2DComparison() {
+      public void of(Rectangle2D expected) {
+        Rectangle2D actual = (Rectangle2D) Rectangle2DSubject.this.actual();
+        Preconditions.checkNotNull(
+            actual, "actual value cannot be null. tolerance=%s expected=%s", tolerance, expected);
+        Rectangle2DSubject.checkTolerance(tolerance);
+        if (!MathUtil.notEqualWithinTolerance(actual.getMinX(), expected.getMinX(), tolerance)
+            && !MathUtil.notEqualWithinTolerance(actual.getMinY(), expected.getMinY(), tolerance)
+            && !MathUtil.notEqualWithinTolerance(actual.getMaxX(), expected.getMaxX(), tolerance)
+            && !MathUtil.notEqualWithinTolerance(actual.getMaxY(), expected.getMaxY(), tolerance)) {
+          Rectangle2DSubject.this.failWithRawMessage(
+              "%s and <%s> should have been finite values not within <%s> of each other",
+              new Object[] {Rectangle2DSubject.this.actualAsString(), expected, tolerance});
         }
+      }
+    };
+  }
 
-        /** @deprecated */
-        @Deprecated
-        public int hashCode() {
-            throw new UnsupportedOperationException("Subject.hashCode() is not supported.");
-        }
+  public abstract static class TolerantRectangle2DComparison {
+    private TolerantRectangle2DComparison() {}
+
+    public abstract void of(Rectangle2D var1);
+
+    /** @deprecated */
+    @Deprecated
+    public boolean equals(@Nullable Object o) {
+      throw new UnsupportedOperationException(
+          "If you meant to compare rectangles, use .of(rectangle) instead.");
     }
 
+    /** @deprecated */
+    @Deprecated
+    public int hashCode() {
+      throw new UnsupportedOperationException("Subject.hashCode() is not supported.");
+    }
+  }
 }

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/truth/SubjectExtensionTest.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/truth/SubjectExtensionTest.java
@@ -1,0 +1,33 @@
+package edu.uci.ics.jung.layout.truth;
+
+import edu.uci.ics.jung.layout.model.Point;
+import org.junit.Test;
+
+import java.awt.geom.Rectangle2D;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static edu.uci.ics.jung.layout.truth.PointSubject.assertThat;
+import static edu.uci.ics.jung.layout.truth.PointSubject.points;
+import static edu.uci.ics.jung.layout.truth.Rectangle2DSubject.rectangles;
+
+public class SubjectExtensionTest {
+
+    @Test
+    public void testPoints() {
+
+        assertWithMessage("they were not close enough").about(points()).that(Point.of(1.0, 1.0)).isWithin(0.1).of(Point.of(1.0, .9));
+        assertThat(Point.of(1.0, 1.0)).isWithin(0.1).of(Point.of(.9, 0.9));
+        assertThat(Point.of(1.0, 0.8)).isNotWithin(0.1).of(Point.of(1.0, 1.0));
+    }
+
+    @Test
+    public void testRectangle2Ds() {
+
+        assertWithMessage("they were not close enough").about(rectangles()).that(new Rectangle2D.Double(1.0, 1.0, 5, 5))
+                .isWithin(0.1).of(new Rectangle2D.Double(1.0, .9, 5, 5));
+        Rectangle2DSubject.assertThat(new Rectangle2D.Double(1.0, 1.0, 5.0, 5.0)).isWithin(0.1)
+                .of(new Rectangle2D.Double(1.0, 1.0, 5.0, 4.9));
+        Rectangle2DSubject.assertThat(new Rectangle2D.Double(1.0, 0.8, 5, 5)).isNotWithin(0.1).of(new Rectangle2D.Double(1.0, 1.0, 5, 5));
+    }
+
+}

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/truth/SubjectExtensionTest.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/layout/truth/SubjectExtensionTest.java
@@ -1,33 +1,41 @@
 package edu.uci.ics.jung.layout.truth;
 
-import edu.uci.ics.jung.layout.model.Point;
-import org.junit.Test;
-
-import java.awt.geom.Rectangle2D;
-
 import static com.google.common.truth.Truth.assertWithMessage;
 import static edu.uci.ics.jung.layout.truth.PointSubject.assertThat;
 import static edu.uci.ics.jung.layout.truth.PointSubject.points;
 import static edu.uci.ics.jung.layout.truth.Rectangle2DSubject.rectangles;
 
+import edu.uci.ics.jung.layout.model.Point;
+import java.awt.geom.Rectangle2D;
+import org.junit.Test;
+
 public class SubjectExtensionTest {
 
-    @Test
-    public void testPoints() {
+  @Test
+  public void testPoints() {
 
-        assertWithMessage("they were not close enough").about(points()).that(Point.of(1.0, 1.0)).isWithin(0.1).of(Point.of(1.0, .9));
-        assertThat(Point.of(1.0, 1.0)).isWithin(0.1).of(Point.of(.9, 0.9));
-        assertThat(Point.of(1.0, 0.8)).isNotWithin(0.1).of(Point.of(1.0, 1.0));
-    }
+    assertWithMessage("they were not close enough")
+        .about(points())
+        .that(Point.of(1.0, 1.0))
+        .isWithin(0.1)
+        .of(Point.of(1.0, .9));
+    assertThat(Point.of(1.0, 1.0)).isWithin(0.1).of(Point.of(.9, 0.9));
+    assertThat(Point.of(1.0, 0.8)).isNotWithin(0.1).of(Point.of(1.0, 1.0));
+  }
 
-    @Test
-    public void testRectangle2Ds() {
+  @Test
+  public void testRectangle2Ds() {
 
-        assertWithMessage("they were not close enough").about(rectangles()).that(new Rectangle2D.Double(1.0, 1.0, 5, 5))
-                .isWithin(0.1).of(new Rectangle2D.Double(1.0, .9, 5, 5));
-        Rectangle2DSubject.assertThat(new Rectangle2D.Double(1.0, 1.0, 5.0, 5.0)).isWithin(0.1)
-                .of(new Rectangle2D.Double(1.0, 1.0, 5.0, 4.9));
-        Rectangle2DSubject.assertThat(new Rectangle2D.Double(1.0, 0.8, 5, 5)).isNotWithin(0.1).of(new Rectangle2D.Double(1.0, 1.0, 5, 5));
-    }
-
+    assertWithMessage("they were not close enough")
+        .about(rectangles())
+        .that(new Rectangle2D.Double(1.0, 1.0, 5, 5))
+        .isWithin(0.1)
+        .of(new Rectangle2D.Double(1.0, .9, 5, 5));
+    Rectangle2DSubject.assertThat(new Rectangle2D.Double(1.0, 1.0, 5.0, 5.0))
+        .isWithin(0.1)
+        .of(new Rectangle2D.Double(1.0, 1.0, 5.0, 4.9));
+    Rectangle2DSubject.assertThat(new Rectangle2D.Double(1.0, 0.8, 5, 5))
+        .isNotWithin(0.1)
+        .of(new Rectangle2D.Double(1.0, 1.0, 5, 5));
+  }
 }


### PR DESCRIPTION
This PR is only to show an example of how to create and unit test 2 extensions to Truth Subject: PointSubject and Rectangle2DSubject. I'm not advocating that we make these specific changes, as it is a lot of new code merely for the support of a Truth-based testing capability for Points and Rectangle2Ds.