### PR TITLE
Make CTreeNetwork#setDepth like CTree#setDepth

### DIFF
--- a/jung-api/src/main/java/edu/uci/ics/jung/graph/DelegateCTree.java
+++ b/jung-api/src/main/java/edu/uci/ics/jung/graph/DelegateCTree.java
@@ -178,7 +178,7 @@ class DelegateCTree<N> extends AbstractGraph<N> implements MutableCTree<N> {
       height = Optional.of(0);
     } else {
       depths.putIfAbsent(parent, 0);
-      int nodeDepth = Math.max(depths.get(parent) + 1, height.orElseThrow(AssertionError::new));
+      int nodeDepth = Math.max(depths.get(parent) + 1, height.orElse(0));
       depths.put(node, nodeDepth);
       height = Optional.of(nodeDepth);
     }

--- a/jung-api/src/main/java/edu/uci/ics/jung/graph/DelegateCTreeNetwork.java
+++ b/jung-api/src/main/java/edu/uci/ics/jung/graph/DelegateCTreeNetwork.java
@@ -229,8 +229,9 @@ class DelegateCTreeNetwork<N, E> extends AbstractNetwork<N, E>
       height = Optional.of(0);
     } else {
       depths.putIfAbsent(parent, 0);
-      int nodeDepth = depths.get(parent) + 1;
-      height = Optional.of(Math.max(nodeDepth, height.orElseThrow(AssertionError::new)));
+      int nodeDepth = Math.max(depths.get(parent) + 1, height.orElse(0));
+      depths.put(node, nodeDepth);
+      height = Optional.of(nodeDepth);
     }
   }
 


### PR DESCRIPTION
Also throw `AssertionError` less and use hopefully sensible default values instead.

This commit should fix up TreeCollapseDemo a bit, as originally reported by @tomnelson in #167. (I can't find the original message now in #167 where the breakage was reported - I'm going by my old email records of the conversation on the PR.)

However, TreeCollapseDemo is still a bit broken, since it depends on `TreeUtils#addSubTree` allowing null to be passed to its parameter `subTreeParent` parameter, which currently it disallows. I will address this in a future PR.