### PR TITLE
Fix TreeCollapseDemo

### DIFF
--- a/jung-api/src/main/java/edu/uci/ics/jung/graph/util/TreeUtils.java
+++ b/jung-api/src/main/java/edu/uci/ics/jung/graph/util/TreeUtils.java
@@ -105,11 +105,14 @@ public class TreeUtils {
    *
    * @param <N> the node type
    * @param <E> the edge type
-   * @param tree the tree to which {@code subTree} is to be added
+   * @param tree the tree to which {@code subTree} is to be added; must contain no nodes if {@code
+   *     subTreeParent} is {@code null}
    * @param subTree the tree which is to be grafted on to {@code tree}
    * @param subTreeParent the parent of the root of {@code subTree} in its new position in {@code
-   *     tree}
-   * @param connectingEdge the edge used to connect {@code subTreeParent} to {@code subtree}'s root
+   *     tree}; can be {@code null} to represent "no parent" i.e. if {@code tree} contains no node;
+   *     must be {@code null} if {@code tree} contains no nodes
+   * @param connectingEdge the edge used to connect {@code subTreeParent} to {@code subtree}'s root;
+   *     must be {@code null} if {@code subTreeParent} is {@code null}
    */
   public static <N, E> void addSubTree(
       MutableCTreeNetwork<N, E> tree,
@@ -118,17 +121,26 @@ public class TreeUtils {
       E connectingEdge) {
     checkNotNull(tree, "tree");
     checkNotNull(subTree, "subTree");
-    checkNotNull(subTreeParent, "subTreeParent");
-    checkNotNull(connectingEdge, "connectingEdge");
-    checkArgument(tree.nodes().contains(subTreeParent), "'tree' does not contain 'subTreeParent'");
+    checkArgument(
+        subTreeParent == null || tree.nodes().contains(subTreeParent),
+        "'tree' does not contain 'subTreeParent'");
+    if (subTreeParent != null) {
+      checkNotNull(connectingEdge, "connectingEdge");
+    }
+
     if (!subTree.root().isPresent()) {
       // empty subtree; nothing to do
       return;
     }
 
     N subTreeRoot = subTree.root().get();
-    checkNotNull(connectingEdge);
-    tree.addEdge(subTreeParent, subTreeRoot, connectingEdge);
+    if (subTreeParent == null) {
+      checkArgument(
+          tree.nodes().isEmpty(),
+          "'tree' unexpectedly contains nodes, given that 'subTreeParent' is null");
+    } else {
+      tree.addEdge(subTreeParent, subTreeRoot, connectingEdge);
+    }
     addFromSubTree(tree, subTree, subTreeRoot);
   }
 

--- a/jung-api/src/main/java/edu/uci/ics/jung/graph/util/TreeUtils.java
+++ b/jung-api/src/main/java/edu/uci/ics/jung/graph/util/TreeUtils.java
@@ -105,14 +105,11 @@ public class TreeUtils {
    *
    * @param <N> the node type
    * @param <E> the edge type
-   * @param tree the tree to which {@code subTree} is to be added; must contain no nodes if {@code
-   *     subTreeParent} is {@code null}
+   * @param tree the tree to which {@code subTree} is to be added
    * @param subTree the tree which is to be grafted on to {@code tree}
    * @param subTreeParent the parent of the root of {@code subTree} in its new position in {@code
-   *     tree}; can be {@code null} to represent "no parent" i.e. if {@code tree} contains no node;
-   *     must be {@code null} if {@code tree} contains no nodes
-   * @param connectingEdge the edge used to connect {@code subTreeParent} to {@code subtree}'s root;
-   *     must be {@code null} if {@code subTreeParent} is {@code null}
+   *     tree}
+   * @param connectingEdge the edge used to connect {@code subTreeParent} to {@code subtree}'s root
    */
   public static <N, E> void addSubTree(
       MutableCTreeNetwork<N, E> tree,
@@ -121,12 +118,9 @@ public class TreeUtils {
       E connectingEdge) {
     checkNotNull(tree, "tree");
     checkNotNull(subTree, "subTree");
-    checkArgument(
-        subTreeParent == null || tree.nodes().contains(subTreeParent),
-        "'tree' does not contain 'subTreeParent'");
-    if (subTreeParent != null) {
-      checkNotNull(connectingEdge, "connectingEdge");
-    }
+    checkNotNull(subTreeParent, "subTreeParent");
+    checkNotNull(connectingEdge, "connectingEdge");
+    checkArgument(tree.nodes().contains(subTreeParent), "'tree' does not contain 'subTreeParent'");
 
     if (!subTree.root().isPresent()) {
       // empty subtree; nothing to do
@@ -134,13 +128,7 @@ public class TreeUtils {
     }
 
     N subTreeRoot = subTree.root().get();
-    if (subTreeParent == null) {
-      checkArgument(
-          tree.nodes().isEmpty(),
-          "'tree' unexpectedly contains nodes, given that 'subTreeParent' is null");
-    } else {
-      tree.addEdge(subTreeParent, subTreeRoot, connectingEdge);
-    }
+    tree.addEdge(subTreeParent, subTreeRoot, connectingEdge);
     addFromSubTree(tree, subTree, subTreeRoot);
   }
 

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/TreeCollapseDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/TreeCollapseDemo.java
@@ -161,8 +161,10 @@ public class TreeCollapseDemo extends JPanel {
         e -> {
           for (Object v : vv.getPickedNodeState().getPicked()) {
             if (v instanceof CTreeNetwork) {
-              TreeCollapser.expand(graph, (CTreeNetwork) v);
-              vv.getModel().setNetwork(graph);
+              CTreeNetwork expandedTree = TreeCollapser.expand(graph, (CTreeNetwork) v);
+              LayoutModel<Object> objectLayoutModel = vv.getModel().getLayoutModel();
+              objectLayoutModel.set(expandedTree, objectLayoutModel.apply(v));
+              vv.getModel().setNetwork(graph, true);
             }
             vv.getPickedNodeState().clear();
             vv.repaint();

--- a/jung-samples/src/main/java/edu/uci/ics/jung/samples/TreeCollapseDemo.java
+++ b/jung-samples/src/main/java/edu/uci/ics/jung/samples/TreeCollapseDemo.java
@@ -160,10 +160,10 @@ public class TreeCollapseDemo extends JPanel {
     expand.addActionListener(
         e -> {
           for (Object v : vv.getPickedNodeState().getPicked()) {
-            if (v instanceof CTreeNetwork) {
-              CTreeNetwork expandedTree = TreeCollapser.expand(graph, (CTreeNetwork) v);
+            if (v instanceof MutableCTreeNetwork) {
+              graph = TreeCollapser.expand(graph, (MutableCTreeNetwork) v);
               LayoutModel<Object> objectLayoutModel = vv.getModel().getLayoutModel();
-              objectLayoutModel.set(expandedTree, objectLayoutModel.apply(v));
+              objectLayoutModel.set(graph, objectLayoutModel.apply(v));
               vv.getModel().setNetwork(graph, true);
             }
             vv.getPickedNodeState().clear();

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
@@ -28,13 +28,12 @@ public class TreeCollapser {
    */
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static MutableCTreeNetwork collapse(MutableCTreeNetwork tree, Object subRoot) {
-    System.out.format("collapse: (1): tree: %s, subRoot: %s%n", tree, subRoot);
     // get the subtree rooted at subRoot
     MutableCTreeNetwork subTree = TreeUtils.getSubTree(tree, subRoot);
     Optional parent = tree.predecessor(subRoot);
     if (parent.isPresent()) {
       // subRoot has a parent, so attach its parent to subTree in its place
-      Object parentEdge = tree.inEdges(subRoot).iterator().next(); // THERE CAN BE ONLY ONE
+      Object parentEdge = Iterables.getOnlyElement(tree.inEdges(subRoot)); // THERE CAN BE ONLY ONE
       tree.removeNode(subRoot);
       tree.addEdge(parent.get(), subTree, parentEdge);
     } else {
@@ -42,13 +41,11 @@ public class TreeCollapser {
       tree.removeNode(subRoot);
       tree.addNode(subTree);
     }
-    System.out.format("collapse: (2): return: %s%n", subTree);
     return subTree;
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
-  public static CTreeNetwork expand(MutableCTreeNetwork tree, CTreeNetwork subTree) {
-    System.out.format("expand: (1): tree: %s, subTree: %s%n", tree, subTree);
+  public static MutableCTreeNetwork expand(MutableCTreeNetwork tree, MutableCTreeNetwork subTree) {
     Optional parent = tree.predecessor(subTree);
     Object parentEdge =
         parent.isPresent()
@@ -57,16 +54,13 @@ public class TreeCollapser {
     tree.removeNode(subTree);
     if (!subTree.root().isPresent()) {
       // then the subTree is empty, so just return the tree itself
-      System.out.format("expand: (2): return: %s%n", tree);
       return tree;
     }
     if (parent.isPresent()) {
       TreeUtils.addSubTree(tree, subTree, parent.get(), parentEdge);
-      System.out.format("expand: (3): return: %s%n", tree);
       return tree;
     } else {
       // then the tree is empty, so just return the subTree itself
-      System.out.format("expand: (2): return: %s%n", subTree);
       return subTree;
     }
   }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
@@ -48,11 +48,11 @@ public class TreeCollapser {
         parent.isPresent()
             ? Iterables.getOnlyElement(tree.inEdges(subTree)) // THERE CAN BE ONLY ONE
             : null;
-    tree.removeNode(subTree);
     if (!subTree.root().isPresent()) {
       // then the subTree is empty, so just return the tree itself
       return tree;
     }
+    tree.removeNode(subTree);
     if (parent.isPresent()) {
       TreeUtils.addSubTree(tree, subTree, parent.get(), parentEdge);
       return tree;

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
@@ -28,6 +28,7 @@ public class TreeCollapser {
    */
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static MutableCTreeNetwork collapse(MutableCTreeNetwork tree, Object subRoot) {
+    System.out.format("collapse: (1): tree: %s, subRoot: %s%n", tree, subRoot);
     // get the subtree rooted at subRoot
     MutableCTreeNetwork subTree = TreeUtils.getSubTree(tree, subRoot);
     Optional parent = tree.predecessor(subRoot);
@@ -41,29 +42,36 @@ public class TreeCollapser {
       tree.removeNode(subRoot);
       tree.addNode(subTree);
     }
+    System.out.format("collapse: (2): return: %s%n", subTree);
     return subTree;
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
-  public static void expand(MutableCTreeNetwork tree, CTreeNetwork subTree) {
+  public static CTreeNetwork expand(MutableCTreeNetwork tree, CTreeNetwork subTree) {
+    System.out.format("expand: (1): tree: %s, subTree: %s%n", tree, subTree);
     Optional parent = tree.predecessor(subTree);
     Object parentEdge =
         parent.isPresent()
-            ? tree.inEdges(subTree).iterator().next() // THERE CAN BE ONLY ONE
+            ? Iterables.getOnlyElement(tree.inEdges(subTree)) // THERE CAN BE ONLY ONE
             : null;
     tree.removeNode(subTree);
     if (!subTree.root().isPresent()) {
-      // then the subTree is empty
-      return;
+      // then the subTree is empty, so just return the tree itself
+      System.out.format("expand: (2): return: %s%n", tree);
+      return tree;
     }
     if (parent.isPresent()) {
       TreeUtils.addSubTree(tree, subTree, parent.get(), parentEdge);
+      System.out.format("expand: (3): return: %s%n", tree);
+      return tree;
     } else {
-      // tree is empty, so just copy all of subTree into tree
-      copyInto(tree, subTree);
+      // then the tree is empty, so just return the subTree itself
+      System.out.format("expand: (2): return: %s%n", subTree);
+      return subTree;
     }
   }
 
+  // currently unused
   private static <N, E> void copyInto(MutableCTreeNetwork<N, E> tree, CTreeNetwork<N, E> subTree) {
     N root = subTree.root().get(); // safe to use .get() as .root() is already known to be present
     tree.addNode(root);

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
@@ -69,6 +69,7 @@ public class TreeCollapser {
     tree.addNode(root);
     // Connect each successively deeper node to its parent
     Iterable<N> insertionOrder =
+        // TODO: Migrate to Traverser when we use a version of Guava that has itg
         TreeTraverser.using(subTree::successors)
             .preOrderTraversal(root)
             .skip(1); // skip the root itself

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
@@ -10,9 +10,6 @@
 package edu.uci.ics.jung.visualization.subLayout;
 
 import com.google.common.collect.Iterables;
-import com.google.common.graph.EndpointPair;
-import com.google.common.graph.Traverser;
-import edu.uci.ics.jung.graph.CTreeNetwork;
 import edu.uci.ics.jung.graph.MutableCTreeNetwork;
 import edu.uci.ics.jung.graph.util.TreeUtils;
 import java.util.Optional;

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
@@ -10,8 +10,8 @@
 package edu.uci.ics.jung.visualization.subLayout;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.TreeTraverser;
 import com.google.common.graph.EndpointPair;
+import com.google.common.graph.Traverser;
 import edu.uci.ics.jung.graph.CTreeNetwork;
 import edu.uci.ics.jung.graph.MutableCTreeNetwork;
 import edu.uci.ics.jung.graph.util.TreeUtils;
@@ -77,10 +77,9 @@ public class TreeCollapser {
     tree.addNode(root);
     // Connect each successively deeper node to its parent
     Iterable<N> insertionOrder =
-        // TODO: Migrate to Traverser when we use a version of Guava that has itg
-        TreeTraverser.using(subTree::successors)
-            .preOrderTraversal(root)
-            .skip(1); // skip the root itself
+        Iterables.skip(
+            Traverser.forTree(subTree).depthFirstPreOrder(root),
+            1); // skip the root itself
     for (N current : insertionOrder) {
       E inEdge = Iterables.getOnlyElement(subTree.inEdges(current));
       EndpointPair<N> endpointPair = subTree.incidentNodes(inEdge);

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
@@ -64,19 +64,4 @@ public class TreeCollapser {
       return subTree;
     }
   }
-
-  // currently unused
-  private static <N, E> void copyInto(MutableCTreeNetwork<N, E> tree, CTreeNetwork<N, E> subTree) {
-    N root = subTree.root().get(); // safe to use .get() as .root() is already known to be present
-    tree.addNode(root);
-    // Connect each successively deeper node to its parent
-    Iterable<N> insertionOrder =
-        Iterables.skip(
-            Traverser.forTree(subTree).depthFirstPreOrder(root), 1); // skip the root itself
-    for (N current : insertionOrder) {
-      E inEdge = Iterables.getOnlyElement(subTree.inEdges(current));
-      EndpointPair<N> endpointPair = subTree.incidentNodes(inEdge);
-      tree.addEdge(endpointPair.nodeU(), endpointPair.nodeV(), inEdge);
-    }
-  }
 }

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/subLayout/TreeCollapser.java
@@ -78,8 +78,7 @@ public class TreeCollapser {
     // Connect each successively deeper node to its parent
     Iterable<N> insertionOrder =
         Iterables.skip(
-            Traverser.forTree(subTree).depthFirstPreOrder(root),
-            1); // skip the root itself
+            Traverser.forTree(subTree).depthFirstPreOrder(root), 1); // skip the root itself
     for (N current : insertionOrder) {
       E inEdge = Iterables.getOnlyElement(subTree.inEdges(current));
       EndpointPair<N> endpointPair = subTree.incidentNodes(inEdge);


### PR DESCRIPTION
Previously, when collapsing and expanding the root node of the tree being viewed, it would throw an unexpected `NullPointerException`. This commit fixes things so that the method which was misbehaving, `TreeUtils#addSubTree`, is able to handle the edge case of populating an empty tree with a given sub-tree, making the given empty tree identical to the given sub-tree.

This is a follow-on to #202.