### PR TITLE
BasicRenderer: remove spurious instanceof check

### DIFF
--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicRenderer.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/renderers/BasicRenderer.java
@@ -84,7 +84,7 @@ public class BasicRenderer<N, E> implements Renderer<N, E> {
 
       for (N v : visibleNodes) {
         renderNode(renderContext, visualizationModel, v);
-        if (v instanceof String) renderNodeLabel(renderContext, visualizationModel, v);
+        renderNodeLabel(renderContext, visualizationModel, v);
       }
     } catch (ConcurrentModificationException cme) {
       renderContext.getScreenDevice().repaint();


### PR DESCRIPTION
This instanceof check is causing node label rendering to not happen when the node type is not String.  I can't see any reason why this check would have been added; it's the RenderContext's node label function's job to convert the node to a String.