### PR TITLE
adding Netbeans IDE ignoring section to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ out/
 .metadata/
 .factoryPath
 bin/
+
+# Netbeans
+/nb-configuration.xml

--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/util/KMeansClusterer.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/util/KMeansClusterer.java
@@ -233,6 +233,11 @@ public class KMeansClusterer<T> {
     this.rand = new Random(random_seed);
   }
 
+  /** Replaces the internal random number generator by a new instance. */
+  public void setRandom(Random random) {
+    this.rand = random;
+  }
+
   /**
    * An exception that indicates that the specified data points cannot be clustered into the number
    * of clusters requested by the user. This will happen if and only if there are fewer distinct


### PR DESCRIPTION
Like for other IDEs this opens the .gitignore section for Apache Netbeans IDE.

Please include it to ignore some project metadata files from this IDE.