### PR TITLE
Fixed flaky test in mst

### DIFF
--- a/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/shortestpath/MinimumSpanningTree.java
+++ b/jung-algorithms/src/main/java/edu/uci/ics/jung/algorithms/shortestpath/MinimumSpanningTree.java
@@ -7,10 +7,10 @@ import com.google.common.graph.NetworkBuilder;
 import com.google.common.graph.ValueGraph;
 import com.google.common.graph.ValueGraphBuilder;
 import edu.uci.ics.jung.algorithms.util.MapBinaryHeap;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.function.Function;
 
 /**
@@ -39,8 +39,8 @@ public class MinimumSpanningTree<N, E> {
    */
   public static <N, E> Network<N, E> extractFrom(
       Network<N, E> graph, Function<? super E, Double> edgeWeights) {
-    Set<N> remainingNodes = new HashSet<>(graph.nodes());
-    Map<N, NodeData<E>> nodeData = new HashMap<>();
+    Set<N> remainingNodes = new TreeSet<>(graph.nodes());
+    Map<N, NodeData<E>> nodeData = new TreeMap<>();
     // initialize node data
     for (N node : remainingNodes) {
       nodeData.put(node, new NodeData<>());
@@ -92,8 +92,8 @@ public class MinimumSpanningTree<N, E> {
    * @param graph the graph from which to extract the minimum spanning forest
    */
   public static <N, V extends Number> ValueGraph<N, V> extractFrom(ValueGraph<N, V> graph) {
-    Set<N> remainingNodes = new HashSet<>(graph.nodes());
-    Map<N, NodeData<N>> nodeData = new HashMap<>();
+    Set<N> remainingNodes = new TreeSet<>(graph.nodes());
+    Map<N, NodeData<N>> nodeData = new TreeMap<>();
     // initialize node data
     for (N node : remainingNodes) {
       nodeData.put(node, new NodeData<>());

--- a/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/shortestpath/TestMinimumSpanningTree.java
+++ b/jung-algorithms/src/test/java/edu/uci/ics/jung/algorithms/shortestpath/TestMinimumSpanningTree.java
@@ -30,6 +30,23 @@ public class TestMinimumSpanningTree extends TestCase {
 
     assertEquals(graph.nodes(), mst.nodes());
     assertEquals(graph.edges(), mst.edges());
+
+    // Add more tests.
+    MutableNetwork<String, Integer> graph2 = NetworkBuilder.directed().build();
+    graph2.addNode("B0");
+    graph2.addNode("B2");
+    graph2.addNode("B3");
+    graph2.addEdge("A", "B1", 0);
+    graph2.addEdge("A", "B2", 3);
+    graph2.addEdge("A", "B3", 5);
+
+    Network<String, Integer> mst2 = MinimumSpanningTree.extractFrom(graph2, e -> 1.0);
+
+    // Test mutableNetwork.
+    MutableNetwork<String, Integer> graph3 = NetworkBuilder.directed().build();
+
+    assertEquals(graph2.nodes(), mst2.nodes());
+    assertEquals(graph2.edges(), mst2.edges());
   }
 
   // TODO: add tests:


### PR DESCRIPTION
The problem comes from the implementation of Minimum spanning tree rather than `MutableNetwork`, i.e., the implementation of `MutatableNetwork` is free from generating flaky results. In the implementation of Minimum spanning tree, nodes and node data are stored in hashset and hashmap before processing, where both data structures have indeterministic ordering of their member data. Thus, although `graph.edges()` will return all edges in a graph, they are likely to have different ordering depending on different test iterations and causing `assertEqual` to fail sometimes and produces flaky test.

Thus, the proposed fix replaces `hashSet` and `hashMap` with `TreeSet` and `TreeMap`, where the ordering of elements are deterministic. 

Another possible way is to adjust the minimum spanning tree test, where the test ignores the ordering and only checks whether elements are present in both graph (possiblt using `containsInAnyOrder`). But it might be a less ideal solution and having fixed ordering of edges and nodes is more stable.

Additional test is provided for minimum spanning tree. More tests for `ValueGraph` can be added for more coverage.

Fixes issue #256. 